### PR TITLE
Normalize structured chat content blocks for OpenClaw compatibility

### DIFF
--- a/packages/server/src/routes/v1/chat-completions.ts
+++ b/packages/server/src/routes/v1/chat-completions.ts
@@ -82,7 +82,7 @@ function normalizeContentBlock(part: unknown): string {
   return stringifyUnknown(block);
 }
 
-function normalizeMessageContent(content: unknown): string | null {
+function normalizeMessageContent(content: unknown): string {
   if (typeof content === 'string') return sanitizeString(content);
   if (Array.isArray(content)) {
     return sanitizeString(content.map((part) => normalizeContentBlock(part)).filter(Boolean).join('\n'));
@@ -90,7 +90,8 @@ function normalizeMessageContent(content: unknown): string | null {
   if (content && typeof content === 'object') {
     return sanitizeString(normalizeContentBlock(content));
   }
-  return null;
+  if (content == null) return '';
+  return sanitizeString(stringifyUnknown(content));
 }
 
 // CLI 에러 메시지에서 내부 정보 제거 (파일 경로, 스택 트레이스 등)

--- a/packages/server/src/routes/v1/chat-completions.ts
+++ b/packages/server/src/routes/v1/chat-completions.ts
@@ -34,6 +34,65 @@ function sanitizeString(str: string): string {
   return str.replace(/\x00/g, '');
 }
 
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value == null) return '';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeContentBlock(part: unknown): string {
+  if (typeof part === 'string') return part;
+  if (!part || typeof part !== 'object') return stringifyUnknown(part);
+
+  const block = part as Record<string, unknown>;
+  const type = typeof block.type === 'string' ? block.type : '';
+
+  if (typeof block.text === 'string') return block.text;
+  if (typeof block.content === 'string') return block.content;
+
+  if (Array.isArray(block.content)) {
+    return block.content.map((item) => normalizeContentBlock(item)).filter(Boolean).join('\n');
+  }
+
+  if (type === 'toolCall') {
+    const name = typeof block.name === 'string' ? block.name : 'tool';
+    const args = block.arguments ?? block.input ?? block.args;
+    return `[Tool call ${name}] ${stringifyUnknown(args)}`.trim();
+  }
+
+  if (type === 'toolResult') {
+    const name = typeof block.name === 'string' ? block.name : (typeof block.toolName === 'string' ? block.toolName : 'tool');
+    const result = block.result ?? block.output ?? block.content ?? block.data;
+    return `[Tool result ${name}] ${typeof result === 'string' ? result : stringifyUnknown(result)}`.trim();
+  }
+
+  if (type === 'thinking') {
+    return typeof block.thinking === 'string' ? `[Thinking] ${block.thinking}` : '';
+  }
+
+  if (type === 'input_text') {
+    return typeof block.text === 'string' ? block.text : stringifyUnknown(block);
+  }
+
+  return stringifyUnknown(block);
+}
+
+function normalizeMessageContent(content: unknown): string | null {
+  if (typeof content === 'string') return sanitizeString(content);
+  if (Array.isArray(content)) {
+    return sanitizeString(content.map((part) => normalizeContentBlock(part)).filter(Boolean).join('\n'));
+  }
+  if (content && typeof content === 'object') {
+    return sanitizeString(normalizeContentBlock(content));
+  }
+  return null;
+}
+
 // CLI 에러 메시지에서 내부 정보 제거 (파일 경로, 스택 트레이스 등)
 // 클라이언트에 노출되는 에러 응답에만 적용 — 내부 로그는 원본 유지
 function sanitizeProviderError(message: string): string {
@@ -113,28 +172,11 @@ export function registerChatCompletionsRoute(
           msg.role = 'system';
         }
 
-        // tool 메시지: content가 null/undefined이면 빈 문자열로 정규화
-        if (msg.role === 'tool' && (msg.content === null || msg.content === undefined)) {
-          msg.content = '';
-        }
+        // content를 string으로 정규화 (OpenAI content parts + 구조화 블록 허용)
+        const normalizedContent = normalizeMessageContent(msg.content);
 
-        // content parts 배열 → string으로 정규화
-        if (Array.isArray(msg.content)) {
-          const textParts: string[] = [];
-          for (const part of msg.content) {
-            if (typeof part === 'string') {
-              textParts.push(part);
-            } else if (part && typeof part === 'object' && typeof part.text === 'string') {
-              textParts.push(part.text);
-            }
-          }
-          msg.content = textParts.join('\n');
-        } else if (typeof msg.content !== 'string') {
-          return reply.status(400).send(makeValidationError(`messages[${i}].content must be a string or content parts array.`, 'messages'));
-        }
-
-        // null byte 제거
-        msg.content = sanitizeString(msg.content);
+        // null byte 제거 포함
+        msg.content = normalizedContent;
 
         // 개별 메시지 길이 제한
         if (msg.content.length > v.maxMessageLength) {

--- a/packages/server/src/utils/message-converter.test.ts
+++ b/packages/server/src/utils/message-converter.test.ts
@@ -61,6 +61,32 @@ describe('convertMessages', () => {
     expect(result.userPrompt).toContain('<|user|> What is 2+2?');
   });
 
+  it('tool 메시지를 user 측 문맥으로 직렬화', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'Search the docs.' },
+      { role: 'assistant', content: 'I will look it up.' },
+      { role: 'tool', name: 'web_search', content: 'Found 3 relevant results.' },
+      { role: 'user', content: 'Summarize them.' },
+    ];
+
+    const result = convertMessages(messages);
+    expect(result.userPrompt).toContain('<|user|> Search the docs.');
+    expect(result.userPrompt).toContain('<|assistant|> I will look it up.');
+    expect(result.userPrompt).toContain('<|user|> [Tool result web_search] Found 3 relevant results.');
+    expect(result.userPrompt).toContain('<|user|> Summarize them.');
+  });
+
+  it('구조화된 tool result 문자열도 안전하게 직렬화', () => {
+    const messages: ChatMessage[] = [
+      { role: 'assistant', content: 'Calling tool now.' },
+      { role: 'tool', name: 'browser', content: '{"type":"toolResult","result":"ok"}' },
+      { role: 'user', content: 'continue' },
+    ];
+
+    const result = convertMessages(messages);
+    expect(result.userPrompt).toContain('[Tool result browser]');
+  });
+
   it('프롬프트 인젝션: 사용자 메시지 내 <|assistant|> 구분자가 이스케이프됨', () => {
     const messages: ChatMessage[] = [
       { role: 'user', content: 'Hello' },


### PR DESCRIPTION
## Summary
- normalize structured `messages[].content` blocks in `/v1/chat/completions`
- support OpenClaw-style structured content (`toolCall`, `toolResult`, `thinking`, `input_text`, nested arrays)
- relax content validation so unusual scalar/null values are stringified instead of rejected

## Problem
When star-cliproxy is used behind OpenClaw, chat history passed to `/v1/chat/completions` can contain structured content blocks rather than plain strings.

This caused validation failures such as:
- `messages[17].content must be a string or content parts array`
- `messages[17].content must be a string, object, or content parts array`

That broke multi-turn conversations even after `role: "tool"` compatibility was fixed.

## What changed
### 1. Structured content normalization
`/v1/chat/completions` now flattens content blocks into text before validation/routing.

Handled cases include:
- plain strings
- content arrays
- object content
- `toolCall`
- `toolResult`
- `thinking`
- `input_text`
- nested `content` arrays

### 2. Compatibility-first fallback behavior
If `content` is `null`, `undefined`, or another scalar, it is now converted to a safe string instead of immediately rejecting the request.

## Why
This makes the OpenAI-compatible endpoint much more tolerant of real-world agent/client payloads, especially OpenClaw/OpenAI-style message histories that are already partially normalized but not strictly string-only.

## Validation
Validated locally on the original working tree before branch split:
- message-converter tests passed
- typecheck passed
- server build passed

Also verified end-to-end against a local OpenClaw + star-cliproxy setup.