### PR TITLE
feat(providers): add antigravity cli support

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
 
 # star-cliproxy
 
-AI CLI 구독 플랜을 활용한 OpenAI 호환 API 프록시 — Claude, Codex, Copilot, Gemini CLI 지원
+AI CLI 구독 플랜을 활용한 OpenAI 호환 API 프록시 - Claude, Codex, Copilot, Gemini, Antigravity CLI 지원
 
 ![Dashboard](docs/images/dashboard.png)
 
@@ -32,7 +32,7 @@ response = client.chat.completions.create(
 
 - **OpenAI 호환 API** — `/v1/chat/completions`, `/v1/images/generations`, `/v1/models` 엔드포인트
 - **Anthropic Messages API** — `/v1/messages` 엔드포인트로 Claude Code / Anthropic SDK 네이티브 지원
-- **4개 CLI Provider 지원** — Claude Code, Codex, Copilot CLI, Gemini CLI
+- **5개 CLI Provider 지원** - Claude Code, Codex, Copilot CLI, Gemini CLI, Antigravity CLI
 - **HTTP Provider** — OpenAI 호환 HTTP API 서버 직접 연결 (MLX serve, llama.cpp, vLLM, Ollama, LM Studio 등) — 래퍼 스크립트 불필요
 - **Claude Agent SDK 모드** — Claude 프로바이더의 선택적 SDK 실행 모드 (세션 재사용, 도구 제어, 비용 제한)
 - **플러그인 시스템** — 메인 코드 수정 없이 커스텀 프로바이더 추가 가능 ([플러그인 가이드](./plugins/README.md))
@@ -74,6 +74,7 @@ response = client.chat.completions.create(
 | [Codex](https://github.com/openai/codex) | ChatGPT Plus / Pro | `npm install -g @openai/codex` |
 | [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | GitHub Copilot | `gh extension install github/gh-copilot` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google AI Studio | `npm install -g @google/gemini-cli` |
+| [Antigravity CLI](https://antigravity.google/) | Google AI Pro / Ultra | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` |
 
 > **HTTP Provider:** OpenAI 호환 API를 제공하는 로컬 서버(MLX serve, llama.cpp, vLLM, Ollama, LM Studio)는 대시보드에서 바로 추가할 수 있습니다 — CLI 도구나 플러그인 없이 사용 가능.
 >
@@ -135,6 +136,9 @@ providers:
   gemini:
     enabled: false    # 설치 안 된 경우 비활성화
     cli_path: "gemini"
+  agy:
+    enabled: false    # Antigravity CLI 사용
+    cli_path: "agy"
 ```
 
 ### 3. Run
@@ -280,6 +284,7 @@ localcc() {
 | `gpt-4o` | Codex | `gpt-5.4` |
 | `gemini-pro` | Gemini | `gemini-2.5-pro` |
 | `gemini-flash` | Gemini | `gemini-2.5-flash` |
+| `antigravity` | Antigravity | `antigravity` |
 
 같은 alias에 여러 provider를 매핑하면 priority 순으로 **자동 폴백**됩니다.
 
@@ -327,6 +332,7 @@ curl http://localhost:8300/v1/chat/completions \
 | Codex | `-c model_reasoning_effort=<level>` | low, medium, high | `xhigh`/`max` → `high` |
 | Copilot | `--effort <level>` | low, medium, high, xhigh | `max` → `xhigh` |
 | Gemini | — | (미지원) | 필드 무시 |
+| Antigravity | 없음 | (미지원) | 필드 무시 |
 
 참고:
 - **CLI 모드 전용**입니다. Codex App Server / Claude SDK 모드는 각자 설정 채널(`~/.codex/config.toml`, `sdk_options`)을 사용하세요.
@@ -416,7 +422,7 @@ model_mappings:
         session_ttl_ms: 3600000   # 1시간
 ```
 
-대시보드 모델 매핑 편집 화면의 **Provider Overrides** 섹션에서 화이트리스트 필드를 폼으로 설정할 수 있습니다 (`codex` provider 선택 시에만 표시). 빈 칸으로 두면 프로바이더 기본값을 따릅니다. 다른 프로바이더(`claude`, `gemini`, `copilot`, `http`)는 현재 `provider_overrides`를 무시합니다.
+대시보드 모델 매핑 편집 화면의 **Provider Overrides** 섹션에서 화이트리스트 필드를 폼으로 설정할 수 있습니다 (`codex` provider 선택 시에만 표시). 빈 칸으로 두면 프로바이더 기본값을 따릅니다. 다른 프로바이더(`claude`, `gemini`, `copilot`, `agy`, `http`)는 현재 `provider_overrides`를 무시합니다.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # star-cliproxy
 
-An OpenAI-compatible API proxy powered by your AI CLI subscriptions — Claude, Codex, Copilot, and Gemini
+An OpenAI-compatible API proxy powered by your AI CLI subscriptions - Claude, Codex, Copilot, Gemini, and Antigravity
 
 ![Dashboard](docs/images/dashboard.png)
 
@@ -32,7 +32,7 @@ response = client.chat.completions.create(
 
 - **OpenAI-compatible API** — `/v1/chat/completions`, `/v1/images/generations`, and `/v1/models` endpoints
 - **Anthropic Messages API** — `/v1/messages` endpoint for native Claude Code / Anthropic SDK support
-- **Four CLI providers** — Claude Code, Codex, Copilot CLI, Gemini CLI
+- **Five CLI providers** - Claude Code, Codex, Copilot CLI, Gemini CLI, Antigravity CLI
 - **HTTP providers** — connect any OpenAI-compatible HTTP API (MLX serve, llama.cpp, vLLM, Ollama, LM Studio, etc.) with no wrapper scripts
 - **Claude Agent SDK mode** — optional SDK execution for Claude provider with session reuse, fine-grained tool control, and budget limits
 - **Plugin system** — extend with custom providers without modifying the main codebase (see [Plugin Guide](./plugins/README.md))
@@ -74,6 +74,7 @@ response = client.chat.completions.create(
 | [Codex](https://github.com/openai/codex) | ChatGPT Plus / Pro | `npm install -g @openai/codex` |
 | [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | GitHub Copilot | `gh extension install github/gh-copilot` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google AI Studio | `npm install -g @google/gemini-cli` |
+| [Antigravity CLI](https://antigravity.google/) | Google AI Pro / Ultra | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` |
 
 > **HTTP providers:** Any local server with an OpenAI-compatible API (MLX serve, llama.cpp, vLLM, Ollama, LM Studio) can be added directly from the dashboard — no CLI tool or plugin needed. See [HTTP Providers](#http-providers) below.
 >
@@ -135,6 +136,9 @@ providers:
   gemini:
     enabled: false    # disable if not installed
     cli_path: "gemini"
+  agy:
+    enabled: false    # use Antigravity CLI
+    cli_path: "agy"
 ```
 
 ### 3. Run
@@ -281,6 +285,7 @@ Default mappings (add or modify from the dashboard):
 | `gpt-4o` | Codex | `gpt-5.4` |
 | `gemini-pro` | Gemini | `gemini-2.5-pro` |
 | `gemini-flash` | Gemini | `gemini-2.5-flash` |
+| `antigravity` | Antigravity | `antigravity` |
 
 Mapping the same alias to multiple providers enables **automatic fallback** in priority order.
 
@@ -328,6 +333,7 @@ Levels: `low` · `medium` · `high` · `xhigh` · `max`. Per-provider mapping:
 | Codex | `-c model_reasoning_effort=<level>` | low, medium, high | `xhigh`/`max` → `high` |
 | Copilot | `--effort <level>` | low, medium, high, xhigh | `max` → `xhigh` |
 | Gemini | — | (unsupported) | field is ignored |
+| Antigravity | none | (unsupported) | field is ignored |
 
 Notes:
 - Applies in **CLI mode** only. Codex App Server / Claude SDK modes use their own config channels (`~/.codex/config.toml`, `sdk_options`).
@@ -417,7 +423,7 @@ model_mappings:
         session_ttl_ms: 3600000   # 1 hour
 ```
 
-In the Dashboard the form exposes the whitelisted fields under **Provider Overrides** (visible only when the provider is `codex`); leave a field blank to inherit the provider default. Other providers (`claude`, `gemini`, `copilot`, `http`) currently ignore `provider_overrides`.
+In the Dashboard the form exposes the whitelisted fields under **Provider Overrides** (visible only when the provider is `codex`); leave a field blank to inherit the provider default. Other providers (`claude`, `gemini`, `copilot`, `agy`, `http`) currently ignore `provider_overrides`.
 
 ## HTTP Providers
 

--- a/packages/server/src/providers/agy-provider.test.ts
+++ b/packages/server/src/providers/agy-provider.test.ts
@@ -75,14 +75,14 @@ describe('AgyProvider.buildArgs', () => {
     expect(args).not.toContain('gemini-3-flash');
   });
 
-  it('extra_args를 -p prompt 뒤에 그대로 append', () => {
+  it('extra_args를 -p prompt 앞에 그대로 prepend', () => {
     const provider = new AgyProvider(baseConfig({
       extra_args: ['--dangerously-skip-permissions', '--sandbox'],
     }));
     const args = (provider as unknown as { buildArgs(opts: ExecuteOptions): string[] }).buildArgs(
       baseOptions(),
     );
-    expect(args).toEqual(['-p', 'hello', '--dangerously-skip-permissions', '--sandbox']);
+    expect(args).toEqual(['--dangerously-skip-permissions', '--sandbox', '-p', 'hello']);
   });
 
   it('800KB 초과 prompt는 빌드 단계에서 즉시 throw (ARG_MAX 보호)', () => {

--- a/packages/server/src/providers/agy-provider.ts
+++ b/packages/server/src/providers/agy-provider.ts
@@ -52,9 +52,10 @@ export class AgyProvider extends BaseProvider {
       );
     }
 
-    const args: string[] = ['-p', prompt];
-    args.push(...this.config.extra_args);
-    return args;
+    // agy parses print-mode flags before the print prompt. Keep user-provided
+    // flags before -p so options such as --print-timeout apply to this run
+    // instead of being interpreted as prompt text or ignored after the prompt.
+    return [...this.config.extra_args, '-p', prompt];
   }
 
   // agy는 plain text를 stdout으로 흘리므로 BaseProvider의 NDJSON 라인 파싱을 우회.


### PR DESCRIPTION
**Summary**
- documents Antigravity CLI as a built-in CLI provider in English and Korean READMEs
- updates Antigravity examples, model mapping docs, and provider override notes
- fixes `agy` argument ordering so `extra_args` like `--print-timeout` are passed before `-p <prompt>`

**Verification**
- `npm test -- packages/server/src/providers/agy-provider.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `agy --print-timeout 90s --print "..."`
- built `AgyProvider` smoke with real `agy`, returned `provider agy ok`

**Note**
- `npm run lint` could not run because `eslint` is not installed in the repo dependencies.