### PR TITLE
feat(providers): add xAI Grok Build CLI as a built-in provider

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
 
 # star-cliproxy
 
-AI CLI 구독 플랜을 활용한 OpenAI 호환 API 프록시 - Claude, Codex, Copilot, Gemini, Antigravity CLI 지원
+AI CLI 구독 플랜을 활용한 OpenAI 호환 API 프록시 - Claude, Codex, Copilot, Gemini, Antigravity, Grok CLI 지원
 
 ![Dashboard](docs/images/dashboard.png)
 
@@ -32,7 +32,7 @@ response = client.chat.completions.create(
 
 - **OpenAI 호환 API** — `/v1/chat/completions`, `/v1/images/generations`, `/v1/models` 엔드포인트
 - **Anthropic Messages API** — `/v1/messages` 엔드포인트로 Claude Code / Anthropic SDK 네이티브 지원
-- **5개 CLI Provider 지원** - Claude Code, Codex, Copilot CLI, Gemini CLI, Antigravity CLI
+- **6개 CLI Provider 지원** - Claude Code, Codex, Copilot CLI, Gemini CLI, Antigravity CLI, Grok Build CLI
 - **HTTP Provider** — OpenAI 호환 HTTP API 서버 직접 연결 (MLX serve, llama.cpp, vLLM, Ollama, LM Studio 등) — 래퍼 스크립트 불필요
 - **Claude Agent SDK 모드** — Claude 프로바이더의 선택적 SDK 실행 모드 (세션 재사용, 도구 제어, 비용 제한)
 - **플러그인 시스템** — 메인 코드 수정 없이 커스텀 프로바이더 추가 가능 ([플러그인 가이드](./plugins/README.md))
@@ -75,6 +75,7 @@ response = client.chat.completions.create(
 | [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | GitHub Copilot | `gh extension install github/gh-copilot` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google AI Studio | `npm install -g @google/gemini-cli` |
 | [Antigravity CLI](https://antigravity.google/) | Google AI Pro / Ultra | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` |
+| [Grok Build CLI](https://x.ai/cli) | SuperGrok / X Premium+ | `curl -fsSL https://x.ai/cli/install.sh \| bash` |
 
 > **HTTP Provider:** OpenAI 호환 API를 제공하는 로컬 서버(MLX serve, llama.cpp, vLLM, Ollama, LM Studio)는 대시보드에서 바로 추가할 수 있습니다 — CLI 도구나 플러그인 없이 사용 가능.
 >
@@ -139,6 +140,10 @@ providers:
   agy:
     enabled: false    # Antigravity CLI 사용
     cli_path: "agy"
+  grok:
+    enabled: true     # xAI Grok Build CLI (grok login 필요)
+    cli_path: "grok"
+    default_model: "grok-build"
 ```
 
 ### 3. Run
@@ -285,6 +290,7 @@ localcc() {
 | `gemini-pro` | Gemini | `gemini-2.5-pro` |
 | `gemini-flash` | Gemini | `gemini-2.5-flash` |
 | `antigravity` | Antigravity | `antigravity` |
+| `grok-build` | Grok | `grok-build` |
 
 같은 alias에 여러 provider를 매핑하면 priority 순으로 **자동 폴백**됩니다.
 
@@ -333,6 +339,7 @@ curl http://localhost:8300/v1/chat/completions \
 | Copilot | `--effort <level>` | low, medium, high, xhigh | `max` → `xhigh` |
 | Gemini | — | (미지원) | 필드 무시 |
 | Antigravity | 없음 | (미지원) | 필드 무시 |
+| Grok | — | (미지원) | 필드 무시 |
 
 참고:
 - **CLI 모드 전용**입니다. Codex App Server / Claude SDK 모드는 각자 설정 채널(`~/.codex/config.toml`, `sdk_options`)을 사용하세요.
@@ -422,7 +429,7 @@ model_mappings:
         session_ttl_ms: 3600000   # 1시간
 ```
 
-대시보드 모델 매핑 편집 화면의 **Provider Overrides** 섹션에서 화이트리스트 필드를 폼으로 설정할 수 있습니다 (`codex` provider 선택 시에만 표시). 빈 칸으로 두면 프로바이더 기본값을 따릅니다. 다른 프로바이더(`claude`, `gemini`, `copilot`, `agy`, `http`)는 현재 `provider_overrides`를 무시합니다.
+대시보드 모델 매핑 편집 화면의 **Provider Overrides** 섹션에서 화이트리스트 필드를 폼으로 설정할 수 있습니다 (`codex` provider 선택 시에만 표시). 빈 칸으로 두면 프로바이더 기본값을 따릅니다. 다른 프로바이더(`claude`, `gemini`, `copilot`, `agy`, `grok`, `http`)는 현재 `provider_overrides`를 무시합니다.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # star-cliproxy
 
-An OpenAI-compatible API proxy powered by your AI CLI subscriptions - Claude, Codex, Copilot, Gemini, and Antigravity
+An OpenAI-compatible API proxy powered by your AI CLI subscriptions - Claude, Codex, Copilot, Gemini, Antigravity, and Grok
 
 ![Dashboard](docs/images/dashboard.png)
 
@@ -32,7 +32,7 @@ response = client.chat.completions.create(
 
 - **OpenAI-compatible API** — `/v1/chat/completions`, `/v1/images/generations`, and `/v1/models` endpoints
 - **Anthropic Messages API** — `/v1/messages` endpoint for native Claude Code / Anthropic SDK support
-- **Five CLI providers** - Claude Code, Codex, Copilot CLI, Gemini CLI, Antigravity CLI
+- **Six CLI providers** - Claude Code, Codex, Copilot CLI, Gemini CLI, Antigravity CLI, Grok Build CLI
 - **HTTP providers** — connect any OpenAI-compatible HTTP API (MLX serve, llama.cpp, vLLM, Ollama, LM Studio, etc.) with no wrapper scripts
 - **Claude Agent SDK mode** — optional SDK execution for Claude provider with session reuse, fine-grained tool control, and budget limits
 - **Plugin system** — extend with custom providers without modifying the main codebase (see [Plugin Guide](./plugins/README.md))
@@ -75,6 +75,7 @@ response = client.chat.completions.create(
 | [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | GitHub Copilot | `gh extension install github/gh-copilot` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google AI Studio | `npm install -g @google/gemini-cli` |
 | [Antigravity CLI](https://antigravity.google/) | Google AI Pro / Ultra | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` |
+| [Grok Build CLI](https://x.ai/cli) | SuperGrok / X Premium+ | `curl -fsSL https://x.ai/cli/install.sh \| bash` |
 
 > **HTTP providers:** Any local server with an OpenAI-compatible API (MLX serve, llama.cpp, vLLM, Ollama, LM Studio) can be added directly from the dashboard — no CLI tool or plugin needed. See [HTTP Providers](#http-providers) below.
 >
@@ -139,6 +140,10 @@ providers:
   agy:
     enabled: false    # use Antigravity CLI
     cli_path: "agy"
+  grok:
+    enabled: true     # xAI Grok Build CLI (grok login required)
+    cli_path: "grok"
+    default_model: "grok-build"
 ```
 
 ### 3. Run
@@ -286,6 +291,7 @@ Default mappings (add or modify from the dashboard):
 | `gemini-pro` | Gemini | `gemini-2.5-pro` |
 | `gemini-flash` | Gemini | `gemini-2.5-flash` |
 | `antigravity` | Antigravity | `antigravity` |
+| `grok-build` | Grok | `grok-build` |
 
 Mapping the same alias to multiple providers enables **automatic fallback** in priority order.
 
@@ -334,6 +340,7 @@ Levels: `low` · `medium` · `high` · `xhigh` · `max`. Per-provider mapping:
 | Copilot | `--effort <level>` | low, medium, high, xhigh | `max` → `xhigh` |
 | Gemini | — | (unsupported) | field is ignored |
 | Antigravity | none | (unsupported) | field is ignored |
+| Grok | — | (unsupported) | field is ignored |
 
 Notes:
 - Applies in **CLI mode** only. Codex App Server / Claude SDK modes use their own config channels (`~/.codex/config.toml`, `sdk_options`).
@@ -423,7 +430,7 @@ model_mappings:
         session_ttl_ms: 3600000   # 1 hour
 ```
 
-In the Dashboard the form exposes the whitelisted fields under **Provider Overrides** (visible only when the provider is `codex`); leave a field blank to inherit the provider default. Other providers (`claude`, `gemini`, `copilot`, `agy`, `http`) currently ignore `provider_overrides`.
+In the Dashboard the form exposes the whitelisted fields under **Provider Overrides** (visible only when the provider is `codex`); leave a field blank to inherit the provider default. Other providers (`claude`, `gemini`, `copilot`, `agy`, `grok`, `http`) currently ignore `provider_overrides`.
 
 ## HTTP Providers
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -115,6 +115,28 @@ providers:
     #   - "--sandbox"                       # 터미널 제한 샌드박스 (격리 범위는 agy 1.0.0 문서 기준 불명확)
     # working_dir: "/path/to/safe-workspace"  # 파일 시스템 격리 권장 (--dangerously-skip-permissions 사용 시 필수)
 
+  # xAI Grok Build CLI (grok, "Grok Build TUI") — 2026-05-20 발표.
+  # SuperGrok / X Premium+ 구독 + 사전 로그인 필요 (grok login). 설치 후 `grok models`로 모델 확인.
+  # 헤드리스 단발 실행: grok -m <model> -p "<prompt>" → stdout plain text.
+  #
+  # 동작 (구현 시 반영됨):
+  #   - -m/--model 지원 → 매핑된 actual_model을 실제로 전달. 현재 `grok models`는 grok-build 1종(default) 노출.
+  #   - 출력은 plain text(stdout). 토큰 사용량은 추정값(estimateTokens).
+  #   - 단일-청크 가짜 스트리밍으로 wrap(클라이언트 호환 유지). --reasoning-effort는 미배선(매핑에서 무시).
+  #   - 세션 연속성은 매 호출 신규(messages 전체를 매번 prompt로 직렬화).
+  grok:
+    enabled: true
+    cli_path: "grok"
+    default_model: "grok-build"         # `grok models`의 기본·최신 모델
+    max_concurrent: 5                   # 구독 쿼터 보호를 위해 보수적 기본값
+    timeout_ms: 300000
+    extra_args: []
+    # 옵션 (사용자 옵트인 — 보안/안정성 영향 큰 플래그):
+    # extra_args:
+    #   - "--always-approve"                # 툴 자동 승인 (무인 프록시 운영 시)
+    #                                       # 주의: prompt 내 악성 지시가 working_dir 범위 안에서 실행될 수 있음
+    # working_dir: "/path/to/safe-workspace"  # 파일 시스템 격리 권장 (--always-approve 사용 시 권장)
+
 # 플러그인: 커스텀 프로바이더를 코드 수정 없이 추가
 # plugins/ 디렉토리에 플러그인을 만들고 여기에 등록
 # 자세한 가이드: plugins/README.md, 예제: plugins/example-plugin/
@@ -140,6 +162,8 @@ rate_limits:
     gemini:
       rpm: 20
     agy:
+      rpm: 20
+    grok:
       rpm: 20
 
 cache:
@@ -209,3 +233,8 @@ model_mappings:
   - alias: "antigravity"
     provider: "agy"
     actual_model: "antigravity"
+
+  # xAI Grok Build — 최신 단일 모델 (grok models의 기본값)
+  - alias: "grok-build"
+    provider: "grok"
+    actual_model: "grok-build"

--- a/packages/dashboard/src/pages/DebugPage.tsx
+++ b/packages/dashboard/src/pages/DebugPage.tsx
@@ -132,6 +132,11 @@ function buildTerminalCommand(log: { cliArgs: string | null; httpRequest?: strin
       return cmdArgs.map(escapeShellArg).join(' ');
     }
 
+    if (provider === 'grok') {
+      // grok: prompt가 이미 -p 인수에 직접 들어 있어 stdin 파이프 불필요
+      return cmdArgs.map(escapeShellArg).join(' ');
+    }
+
     // 기타 프로바이더
     const cmd = cmdArgs.map(escapeShellArg).join(' ');
     if (messages) {

--- a/packages/dashboard/src/pages/ModelMappingsPage.tsx
+++ b/packages/dashboard/src/pages/ModelMappingsPage.tsx
@@ -133,7 +133,7 @@ export default function ModelMappingsPage() {
   const [testResult, setTestResult] = useState<TestModelResult | null>(null);
   const [rowTesting, setRowTesting] = useState<string | null>(null);
   const [rowTestResult, setRowTestResult] = useState<{ id: string; result: TestModelResult } | null>(null);
-  const [providerNames, setProviderNames] = useState<string[]>(['claude', 'codex', 'copilot', 'gemini', 'agy']);
+  const [providerNames, setProviderNames] = useState<string[]>(['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok']);
   // ephemeral ↔ enable_session_reuse 자동 조정 알림 (3초 후 자동 해제)
   const [overrideMutexNotice, setOverrideMutexNotice] = useState(false);
   const mutexNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -671,9 +671,9 @@ export default function ModelMappingsPage() {
                 <select
                   value={form.reasoning_effort}
                   onChange={(e) => setForm({ ...form, reasoning_effort: e.target.value as ReasoningEffortValue })}
-                  disabled={form.provider === 'gemini' || form.provider === 'agy'}
+                  disabled={form.provider === 'gemini' || form.provider === 'agy' || form.provider === 'grok'}
                   className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded px-3 py-2 text-sm text-gray-800 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                  title={(form.provider === 'gemini' || form.provider === 'agy') ? t('models.reasoningEffortUnsupported') : t('models.reasoningEffortHelp')}
+                  title={(form.provider === 'gemini' || form.provider === 'agy' || form.provider === 'grok') ? t('models.reasoningEffortUnsupported') : t('models.reasoningEffortHelp')}
                 >
                   {REASONING_EFFORT_OPTIONS.map((value) => (
                     <option key={value || 'default'} value={value}>

--- a/packages/dashboard/src/pages/ProvidersPage.tsx
+++ b/packages/dashboard/src/pages/ProvidersPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '../api/client';
 
 // 빌트인 프로바이더 목록
-const BUILTIN_PROVIDERS = new Set(['claude', 'codex', 'copilot', 'gemini', 'agy']);
+const BUILTIN_PROVIDERS = new Set(['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok']);
 
 interface ProviderState {
   info: ProviderInfo;

--- a/packages/dashboard/src/pages/RateLimitsPage.tsx
+++ b/packages/dashboard/src/pages/RateLimitsPage.tsx
@@ -5,7 +5,7 @@ import { fetchRateLimits, updateRateLimits, fetchProviders, type RateLimitsConfi
 export default function RateLimitsPage() {
   const { t } = useTranslation();
   const [config, setConfig] = useState<RateLimitsConfig | null>(null);
-  const [providerNames, setProviderNames] = useState<string[]>(['claude', 'codex', 'copilot', 'gemini', 'agy']);
+  const [providerNames, setProviderNames] = useState<string[]>(['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok']);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -82,6 +82,8 @@ const BUILTIN_DEFAULTS: Record<string, { cliPath: string; defaultModel: string }
   gemini: { cliPath: 'gemini', defaultModel: 'gemini-2.5-pro' },
   // agy 1.0.0은 -m/--model 미지원 → defaultModel은 응답 메타데이터 표시용
   agy: { cliPath: 'agy', defaultModel: 'antigravity' },
+  // xAI Grok Build CLI (`grok`) — -m/--model 지원, 헤드리스 `grok -p`
+  grok: { cliPath: 'grok', defaultModel: 'grok-build' },
 };
 
 export function loadConfig(configPath?: string): AppConfig {
@@ -203,6 +205,8 @@ export function loadConfig(configPath?: string): AppConfig {
       { alias: 'gemini-flash', provider: 'gemini', actual_model: 'gemini-2.5-flash' },
       // Antigravity 1.0.0: actual_model은 표시용
       { alias: 'antigravity', provider: 'agy', actual_model: 'antigravity' },
+      // xAI Grok Build — 최신 단일 모델
+      { alias: 'grok-build', provider: 'grok', actual_model: 'grok-build' },
     ],
   };
 }

--- a/packages/server/src/providers/grok-provider.test.ts
+++ b/packages/server/src/providers/grok-provider.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ExecuteOptions, ProviderConfigYaml, ProviderEvent } from '@star-cliproxy/shared';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+
+// ESM 환경에서 export를 직접 spy할 수 없으므로 vi.mock 팩토리로 spawn 자체를 교체.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+import { spawn } from 'node:child_process';
+import { GrokProvider } from './grok-provider.js';
+
+const spawnMock = vi.mocked(spawn);
+
+function baseConfig(extra: Partial<ProviderConfigYaml> = {}): ProviderConfigYaml {
+  return {
+    enabled: true,
+    cli_path: 'grok',
+    default_model: 'grok-build',
+    max_concurrent: 1,
+    timeout_ms: 30_000,
+    extra_args: [],
+    ...extra,
+  };
+}
+
+function baseOptions(extra: Partial<ExecuteOptions> = {}): ExecuteOptions {
+  return {
+    messages: [{ role: 'user', content: 'hello' }],
+    model: 'grok-build',
+    stream: false,
+    ...extra,
+  };
+}
+
+// child_process.spawn 모킹 — 실제 grok 바이너리 호출 없이 stdout/stderr/exitCode 시뮬레이션.
+function fakeChild(stdout: string, stderr = '', exitCode = 0) {
+  const child = new EventEmitter() as unknown as ReturnType<typeof spawn>;
+  (child as unknown as { stdout: Readable }).stdout = Readable.from([Buffer.from(stdout)]);
+  (child as unknown as { stderr: Readable }).stderr = Readable.from([Buffer.from(stderr)]);
+  (child as unknown as { kill: (sig?: string) => boolean }).kill = vi.fn(() => true);
+  (child as unknown as { killed: boolean }).killed = false;
+  (child as unknown as { stdin: { end: () => void; write: () => void } }).stdin = { end: vi.fn(), write: vi.fn() };
+
+  setImmediate(() => (child as unknown as EventEmitter).emit('close', exitCode));
+  return child;
+}
+
+beforeEach(() => {
+  spawnMock.mockReset();
+});
+
+type BuildArgs = { buildArgs(opts: ExecuteOptions): string[] };
+
+describe('GrokProvider.buildArgs', () => {
+  it('프롬프트를 -p, 모델을 -m 인수로 전달', () => {
+    const provider = new GrokProvider(baseConfig());
+    const args = (provider as unknown as BuildArgs).buildArgs(
+      baseOptions({ messages: [{ role: 'user', content: 'ping' }], model: 'grok-build' }),
+    );
+    expect(args[args.indexOf('-m') + 1]).toBe('grok-build');
+    expect(args[args.indexOf('-p') + 1]).toBe('ping');
+  });
+
+  it('options.model이 없으면 default_model을 -m으로 사용', () => {
+    const provider = new GrokProvider(baseConfig({ default_model: 'grok-build' }));
+    const args = (provider as unknown as BuildArgs).buildArgs(
+      baseOptions({ model: '' }),
+    );
+    expect(args[args.indexOf('-m') + 1]).toBe('grok-build');
+  });
+
+  it('extra_args를 -m/-p 앞에 prepend하고 prompt를 마지막에 둠', () => {
+    const provider = new GrokProvider(baseConfig({ extra_args: ['--effort', 'high'] }));
+    const args = (provider as unknown as BuildArgs).buildArgs(baseOptions());
+    expect(args.slice(0, 2)).toEqual(['--effort', 'high']);
+    expect(args[args.length - 2]).toBe('-p');
+    expect(args[args.length - 1]).toBe('hello');
+  });
+
+  it('default_model이 빈 문자열이면 -m을 생략', () => {
+    const provider = new GrokProvider(baseConfig({ default_model: '' }));
+    const args = (provider as unknown as BuildArgs).buildArgs(baseOptions({ model: '' }));
+    expect(args).not.toContain('-m');
+    expect(args[args.indexOf('-p') + 1]).toBe('hello');
+  });
+
+  it('800KB 초과 prompt는 빌드 단계에서 즉시 throw (ARG_MAX 보호)', () => {
+    const provider = new GrokProvider(baseConfig());
+    const huge = 'x'.repeat(800_001);
+    expect(() =>
+      (provider as unknown as BuildArgs).buildArgs(
+        baseOptions({ messages: [{ role: 'user', content: huge }] }),
+      ),
+    ).toThrow(/prompt exceeds/);
+  });
+});
+
+describe('GrokProvider.execute (plain text 파싱)', () => {
+  it('stdout을 trim한 plain text를 content로 반환', async () => {
+    spawnMock.mockReturnValue(fakeChild('  Hello from grok.  \n'));
+    const provider = new GrokProvider(baseConfig());
+    const result = await provider.execute(baseOptions());
+    expect(result.content).toBe('Hello from grok.');
+    expect(result.finishReason).toBe('stop');
+  });
+
+  it('ANSI 색상 시퀀스를 스트립', async () => {
+    spawnMock.mockReturnValue(fakeChild('\x1B[32mGreen\x1B[0m text'));
+    const provider = new GrokProvider(baseConfig());
+    const result = await provider.execute(baseOptions());
+    expect(result.content).toBe('Green text');
+  });
+
+  it('non-zero exit code는 stderr 메시지와 함께 throw', async () => {
+    spawnMock.mockReturnValue(fakeChild('', 'auth required', 1));
+    const provider = new GrokProvider(baseConfig());
+    await expect(provider.execute(baseOptions())).rejects.toThrow(/auth required/);
+  });
+
+  it('토큰 사용량은 estimateTokens 폴백', async () => {
+    spawnMock.mockReturnValue(fakeChild('1234567890'));
+    const provider = new GrokProvider(baseConfig());
+    const result = await provider.execute(baseOptions());
+    // 10 chars → ceil(10/4) = 3 completion tokens
+    expect(result.usage.completionTokens).toBe(3);
+    expect(result.usage.promptTokens).toBe(0);
+  });
+});
+
+describe('GrokProvider.executeStream (단일-청크 가짜 스트리밍)', () => {
+  it('text_delta → usage → done 순서로 이벤트 emit', async () => {
+    spawnMock.mockReturnValue(fakeChild('response body'));
+    const provider = new GrokProvider(baseConfig());
+    const events: ProviderEvent[] = [];
+    for await (const ev of provider.executeStream(baseOptions({ stream: true }))) {
+      events.push(ev);
+    }
+    expect(events.map(e => e.type)).toEqual(['text_delta', 'usage', 'done']);
+    expect((events[0] as { type: 'text_delta'; text: string }).text).toBe('response body');
+    expect((events[2] as { type: 'done'; finishReason: string }).finishReason).toBe('stop');
+  });
+
+  it('빈 응답은 text_delta를 emit하지 않음', async () => {
+    spawnMock.mockReturnValue(fakeChild(''));
+    const provider = new GrokProvider(baseConfig());
+    const events: ProviderEvent[] = [];
+    for await (const ev of provider.executeStream(baseOptions({ stream: true }))) {
+      events.push(ev);
+    }
+    expect(events.map(e => e.type)).toEqual(['usage', 'done']);
+  });
+});

--- a/packages/server/src/providers/grok-provider.ts
+++ b/packages/server/src/providers/grok-provider.ts
@@ -1,0 +1,150 @@
+import type { ExecuteOptions, ExecuteResult, ProviderConfigYaml, ProviderEvent, TokenUsage } from '@star-cliproxy/shared';
+import { BaseProvider, gracefulKill, trackProcess } from './base-provider.js';
+import { convertMessagesToSinglePrompt } from '../utils/message-converter.js';
+import { spawn } from 'node:child_process';
+
+// macOS ARG_MAX = 1MB. 여유 두어 800KB 한도 (agy-provider와 동일 기준).
+// grok 0.2.x는 헤드리스 입력으로 -p <arg>를 사용하므로 프롬프트가 인수 한도에 묶임.
+const MAX_PROMPT_ARG_BYTES = 800_000;
+
+// 8-bit ANSI escape sequences 제거 (terminal color, cursor codes 등).
+// grok은 stdout이 TTY가 아니면 plain text를 내보내지만 방어적으로 스트립.
+const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, '');
+}
+
+function estimateTokens(text: string): TokenUsage {
+  const completionTokens = Math.ceil(text.length / 4);
+  return { promptTokens: 0, completionTokens, totalTokens: completionTokens };
+}
+
+/**
+ * xAI Grok Build CLI (`grok`, "Grok Build TUI") provider — 2026-05-20 발표, v0.2.x 기준.
+ *
+ * 동작:
+ *  - 헤드리스 단발 실행: `grok -m <model> -p <prompt>` → stdout에 응답 plain text 출력 후 종료.
+ *  - -m/--model 지원 → 매핑된 actual_model을 실제로 전달 (agy와의 핵심 차이).
+ *    `grok models`가 노출하는 모델은 현재 `grok-build` 1종(default).
+ *  - --output-format은 streaming-json도 지원하나, 안정성·단순성을 위해 plain 단발 후
+ *    executeStream에서 단일 text_delta + done으로 가짜 스트리밍 wrap (agy와 동일 전략).
+ *  - 세션 연속성은 매 호출 신규 (-c/--continue, -r/--resume은 사용자가 extra_args로만 옵트인).
+ *  - --always-approve 등 권한 우회 플래그는 보안 영향이 커서 기본 미포함, extra_args로 옵트인.
+ */
+export class GrokProvider extends BaseProvider {
+  readonly name = 'grok' as const;
+
+  constructor(config: ProviderConfigYaml) {
+    super(config);
+    this.initParser();
+  }
+
+  // grok CLI는 `-m <model> -p <prompt>` 형태로 단발 실행. messages는 단일 텍스트로 직렬화.
+  protected buildArgs(options: ExecuteOptions): string[] {
+    const model = options.model || this.config.default_model;
+    const prompt = convertMessagesToSinglePrompt(options.messages);
+
+    if (Buffer.byteLength(prompt, 'utf8') > MAX_PROMPT_ARG_BYTES) {
+      throw new Error(
+        `grok: prompt exceeds ${MAX_PROMPT_ARG_BYTES} bytes ` +
+        `(actual ${Buffer.byteLength(prompt, 'utf8')}). grok 헤드리스 모드는 -p 인수로 프롬프트를 받아 ` +
+        `macOS ARG_MAX 1MB 한도에 묶입니다. 메시지를 줄이거나 요약 후 재시도하세요.`
+      );
+    }
+
+    // 사용자 extra_args를 모델/프롬프트 플래그 앞에 배치해 print-mode 옵션이 이 실행에 적용되게 함.
+    // -p <prompt>는 마지막에 두어 프롬프트가 마지막 인수가 되도록 보장.
+    const modelArgs = model ? ['-m', model] : [];
+    return [...this.config.extra_args, ...modelArgs, '-p', prompt];
+  }
+
+  // grok은 plain text를 stdout으로 흘리므로 BaseProvider의 NDJSON 라인 파싱을 우회.
+  // stdout 전체를 단일 응답 텍스트로 처리.
+  override async execute(options: ExecuteOptions): Promise<ExecuteResult> {
+    const args = this.buildArgs({ ...options, stream: false });
+    const { stdout, stderr, exitCode } = await this.runOnce(args, options.signal);
+
+    if (exitCode !== 0) {
+      options.onDebug?.({ cliArgs: [this.config.cli_path, ...args], stdout, stderr });
+      throw new Error(`grok CLI exited with code ${exitCode}: ${stderr.trim() || stdout.trim()}`);
+    }
+
+    options.onDebug?.({ cliArgs: [this.config.cli_path, ...args], stdout, stderr });
+
+    const content = stripAnsi(stdout).trim();
+    return {
+      content,
+      usage: estimateTokens(content),
+      finishReason: 'stop',
+    };
+  }
+
+  // 실시간 스트리밍 출력을 쓰지 않음(plain 단발). 전체 응답을 받은 뒤 단일 chunk로 wrap.
+  // chat completion 스트리밍 호환을 유지하기 위함 (클라이언트 코드 변경 없이 동작).
+  override async *executeStream(options: ExecuteOptions): AsyncIterable<ProviderEvent> {
+    const result = await this.execute({ ...options, stream: false });
+
+    if (result.content) {
+      yield { type: 'text_delta', text: result.content };
+    }
+    yield {
+      type: 'usage',
+      usage: result.usage,
+    };
+    yield {
+      type: 'done',
+      finishReason: result.finishReason ?? 'stop',
+    };
+  }
+
+  // BaseProvider.runProcess는 private이라 재사용 불가 → 동일 패턴 인라인 구현 (agy-provider와 동일).
+  private runOnce(
+    args: string[],
+    signal?: AbortSignal,
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    return new Promise((resolve, reject) => {
+      const isWin = process.platform === 'win32';
+      const child = spawn(this.config.cli_path, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: this.getCleanEnv(),
+        cwd: this.workingDir,
+        shell: isWin,
+      });
+      trackProcess(child);
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+
+      const timeout = setTimeout(() => {
+        gracefulKill(child);
+        reject(new Error(`grok CLI timed out after ${this.config.timeout_ms}ms`));
+      }, this.config.timeout_ms);
+
+      if (signal) {
+        signal.addEventListener('abort', () => {
+          clearTimeout(timeout);
+          gracefulKill(child);
+          reject(new Error('Request cancelled'));
+        }, { once: true });
+      }
+
+      child.stdout?.on('data', (data: Buffer) => stdoutChunks.push(data));
+      child.stderr?.on('data', (data: Buffer) => stderrChunks.push(data));
+
+      child.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(new Error(`Failed to spawn grok CLI: ${err.message}`));
+      });
+
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        resolve({
+          stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+          stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+          exitCode: code ?? 1,
+        });
+      });
+    });
+  }
+}

--- a/packages/server/src/providers/provider-registry.ts
+++ b/packages/server/src/providers/provider-registry.ts
@@ -5,6 +5,7 @@ import { ClaudeProvider } from './claude-provider.js';
 import { CodexProvider } from './codex-provider.js';
 import { CopilotProvider } from './copilot-provider.js';
 import { GeminiProvider } from './gemini-provider.js';
+import { GrokProvider } from './grok-provider.js';
 
 export class ProviderRegistry {
   private providers = new Map<string, BaseProvider>();
@@ -80,6 +81,7 @@ const builtinFactories: Record<string, ProviderFactory> = {
   copilot: (config) => new CopilotProvider(config),
   gemini: (config) => new GeminiProvider(config),
   agy: (config) => new AgyProvider(config),
+  grok: (config) => new GrokProvider(config),
 };
 
 // 설정 기반으로 활성화된 Provider들을 등록

--- a/packages/server/src/routes/admin/dashboard.ts
+++ b/packages/server/src/routes/admin/dashboard.ts
@@ -8,7 +8,7 @@ import type { ActiveRequestTracker } from '../../services/active-requests.js';
 import { HttpProvider } from '../../providers/http-provider.js';
 
 // 빌트인 프로바이더 — kind 분류용. 다른 곳의 동일 상수와 동기 유지 필요.
-const BUILTIN_PROVIDER_NAMES = new Set(['claude', 'codex', 'copilot', 'gemini', 'agy']);
+const BUILTIN_PROVIDER_NAMES = new Set(['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok']);
 type ProviderKind = 'builtin' | 'http' | 'plugin';
 
 interface DashboardDeps {

--- a/packages/server/src/routes/admin/export-import.ts
+++ b/packages/server/src/routes/admin/export-import.ts
@@ -381,7 +381,7 @@ export function registerExportImportRoutes(
     let genericProvidersImported = 0;
     if (body.genericProviders && typeof body.genericProviders === 'object') {
       const now = new Date().toISOString();
-      const BUILTIN_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'agy'];
+      const BUILTIN_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok'];
 
       for (const [name, genericConfig] of Object.entries(body.genericProviders)) {
         // 빌트인 이름 충돌 방지

--- a/packages/server/src/routes/admin/generic-providers.ts
+++ b/packages/server/src/routes/admin/generic-providers.ts
@@ -13,7 +13,7 @@ const GENERIC_PROVIDER_PREFIX = 'generic_provider:';
 const PROVIDER_CONFIG_PREFIX = 'provider_config:';
 
 // 빌트인 프로바이더 이름 (사용 불가)
-const BUILTIN_PROVIDER_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'agy'];
+const BUILTIN_PROVIDER_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok'];
 
 // 프로바이더 이름 유효성 검사 패턴: 소문자·숫자·하이픈, 길이 2-30
 const PROVIDER_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;

--- a/packages/server/src/routes/admin/http-providers.ts
+++ b/packages/server/src/routes/admin/http-providers.ts
@@ -13,7 +13,7 @@ const HTTP_PROVIDER_PREFIX = 'http_provider:';
 const PROVIDER_CONFIG_PREFIX = 'provider_config:';
 
 // 빌트인 프로바이더 이름 (사용 불가)
-const BUILTIN_PROVIDER_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'agy'];
+const BUILTIN_PROVIDER_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok'];
 
 // 프로바이더 이름 유효성 검사 패턴: 소문자·숫자·하이픈, 길이 2-30
 const PROVIDER_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;

--- a/packages/server/src/routes/admin/providers.ts
+++ b/packages/server/src/routes/admin/providers.ts
@@ -18,7 +18,7 @@ interface ProviderDeps {
 
 // DB 키 접두사
 const PROVIDER_CONFIG_PREFIX = 'provider_config:';
-const BUILTIN_PROVIDER_NAMES = new Set(['claude', 'codex', 'copilot', 'gemini', 'agy']);
+const BUILTIN_PROVIDER_NAMES = new Set(['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok']);
 const BUILTIN_RUNTIME_MUTABLE_FIELDS = new Set([
   'enabled',
   'default_model',

--- a/packages/server/src/services/router.ts
+++ b/packages/server/src/services/router.ts
@@ -108,6 +108,10 @@ export class ModelRouter {
     if (/^(antigravity|agy)(-|$)/.test(lower)) {
       return 'agy';
     }
+    // Grok: grok, grok-* 접두사
+    if (/^grok(-|$)/.test(lower)) {
+      return 'grok';
+    }
     return null;
   }
 }

--- a/packages/server/src/utils/stream-transformer.ts
+++ b/packages/server/src/utils/stream-transformer.ts
@@ -450,6 +450,9 @@ parserRegistry.set('gemini', () => new GeminiStreamParser());
 // agy 1.0.0: plain text 출력 — line-based parser는 사실상 사용되지 않지만
 // (AgyProvider.execute/executeStream이 직접 처리) registry 일관성을 위해 PlainTextParser 등록.
 parserRegistry.set('agy', () => new PlainTextParser());
+// grok: plain text 출력 — GrokProvider.execute/executeStream이 직접 처리.
+// registry 일관성을 위해 PlainTextParser 등록.
+parserRegistry.set('grok', () => new PlainTextParser());
 
 // 플러그인에서 커스텀 파서를 등록할 때 사용
 export function registerParser(provider: string, factory: () => StreamParser): void {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -14,7 +14,7 @@ export const DEFAULT_CACHE_MAX_ENTRIES = 1000;
 export const DEFAULT_RATE_LIMIT_RPM = 60;
 export const DEFAULT_RATE_LIMIT_RPD = 1000;
 
-export const PROVIDER_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'agy'] as const;
+export const PROVIDER_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok'] as const;
 
 // 입력 검증 기본값 (파워 유저 기본값)
 export const DEFAULT_MAX_MESSAGE_COUNT = 800;

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -3,7 +3,7 @@
 import type { ChatMessage } from './api.js';
 
 // 빌트인 프로바이더 (메인 코드에 포함)
-export const BUILTIN_PROVIDERS = ['claude', 'codex', 'copilot', 'gemini', 'agy'] as const;
+export const BUILTIN_PROVIDERS = ['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok'] as const;
 export type BuiltinProviderName = typeof BUILTIN_PROVIDERS[number];
 
 // 플러그인 프로바이더까지 포함하는 동적 타입


### PR DESCRIPTION
## Summary
- xAI **Grok Build CLI**(`grok`)를 6번째 빌트인 CLI 프로바이더로 추가 (Antigravity/agy 전용 클래스 패턴 미러링)
- 헤드리스 단발 실행 `grok -m <model> -p <prompt>` → plain text stdout, ANSI strip, 단일-청크 가짜 스트리밍 wrap
- 기본 모델 `grok-build`(= `grok models`의 기본·최신)를 `loader.ts` 시드 + `config.example.yaml`에 등록 → 신규 클론 사용자가 자동으로 받음
- 백엔드 빌트인 분류 목록 5곳 모두에 grok 추가 → 대시보드에서 플러그인이 아닌 빌트인으로 표시
- README(en/ko) 7개 위치 문서화

## Changes
- **신규** `GrokProvider`(`-m/--model` 지원, agy와의 차이) + 단위 테스트 11개
- provider registry / stream-transformer 파서 / router `inferProvider` / shared `BUILTIN_PROVIDERS`·`PROVIDER_NAMES` 배선
- 대시보드: 빌트인 set 4곳, Debug 커맨드 재구성, reasoning-effort 비활성(grok reasoning_effort 미배선)
- `enabled: true` 기본값 (빌트인은 등록을 위해 활성 필요). `grok login` 선행 필요.

## Test plan
- [x] `tsc --build` 클린 (exit 0)
- [x] `vitest run` 전체 통과 — 130 passed | 1 skipped (회귀 없음)
- [x] 대시보드 프로덕션 빌드 클린 (`vite build` exit 0)
- [x] `config.example.yaml` YAML 유효성 — providers.grok / mapping / rpm 모두 OK
- [x] 실 CLI 스모크 `grok -m grok-build -p "..."` → plain text "OK", exit 0

[decision] generic 프로바이더 대신 전용 클래스 선택 — agy와 일관, generic arg-template이 어색하게 다루는 `-m model` 패스스루를 깔끔히 지원.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)