### PR TITLE
fix(dashboard): 통계 기본 기간을 All → 7d로 변경

### DIFF
--- a/packages/dashboard/src/pages/DashboardPage.tsx
+++ b/packages/dashboard/src/pages/DashboardPage.tsx
@@ -24,7 +24,8 @@ export default function DashboardPage() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const [days, setDays] = useState(0);
+  // 기본 기간 7d — 'All'(0)은 기간이 길어지면 불필요한 데이터를 과도하게 조회
+  const [days, setDays] = useState(7);
 
   const load = () => {
     fetchDashboard(days || undefined)


### PR DESCRIPTION
## Summary
- 대시보드 통계 기본 기간이 `All`(days=0)이라 기간이 길어지면 첫 로드 시 전체 데이터를 과도하게 조회
- 기본값을 **7d**로 변경 (`DashboardPage` `useState(0)` → `useState(7)`)
- 기간 셀렉터(1d/7d/30d/90d/All)는 그대로 — 사용자가 언제든 변경 가능
- TrendChart는 이미 기본 24h(최대 7d)라 변경 불필요

## Test plan
- [x] `tsc -b packages/dashboard` 타입체크 통과
- [ ] 재배포 후 15300에서 기본 7d 로드 확인 (머지 후)