### PR TITLE
feat(http): OpenAI function calling(tool_calls) 지원

### DIFF
--- a/packages/server/src/providers/agy-provider.ts
+++ b/packages/server/src/providers/agy-provider.ts
@@ -93,7 +93,8 @@ export class AgyProvider extends BaseProvider {
     };
     yield {
       type: 'done',
-      finishReason: result.finishReason ?? 'stop',
+      // ExecuteResult(OpenAI 'tool_calls') → ProviderDoneEvent('tool_use') 매핑. CLI는 실제로 미발생.
+      finishReason: result.finishReason === 'tool_calls' ? 'tool_use' : (result.finishReason ?? 'stop'),
     };
   }
 

--- a/packages/server/src/providers/grok-provider.ts
+++ b/packages/server/src/providers/grok-provider.ts
@@ -94,7 +94,8 @@ export class GrokProvider extends BaseProvider {
     };
     yield {
       type: 'done',
-      finishReason: result.finishReason ?? 'stop',
+      // ExecuteResult(OpenAI 'tool_calls') → ProviderDoneEvent('tool_use') 매핑. CLI는 실제로 미발생.
+      finishReason: result.finishReason === 'tool_calls' ? 'tool_use' : (result.finishReason ?? 'stop'),
     };
   }
 

--- a/packages/server/src/providers/http-provider.test.ts
+++ b/packages/server/src/providers/http-provider.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { HttpProviderConfig, ExecuteOptions, ProviderEvent } from '@star-cliproxy/shared';
+import { HttpProvider } from './http-provider.js';
+
+const baseConfig: HttpProviderConfig = {
+  enabled: true,
+  base_url: 'http://localhost:8080/v1',
+  default_model: 'test-model',
+  max_concurrent: 1,
+  timeout_ms: 10_000,
+  display_name: 'Test HTTP',
+};
+
+// fetch 모킹 헬퍼: 응답 JSON과 캡처된 요청 body를 반환
+function mockFetch(responseBody: unknown) {
+  const captured: { body?: any } = {};
+  const fn = vi.fn(async (_url: string, init: any) => {
+    captured.body = JSON.parse(init.body as string);
+    return {
+      ok: true,
+      status: 200,
+      headers: { entries: () => [] as [string, string][] },
+      text: async () => JSON.stringify(responseBody),
+    } as unknown as Response;
+  });
+  vi.stubGlobal('fetch', fn);
+  return captured;
+}
+
+function makeOptions(partial: Partial<ExecuteOptions>): ExecuteOptions {
+  return {
+    messages: [{ role: 'user', content: 'hi' }],
+    model: 'test-model',
+    stream: false,
+    ...partial,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('HttpProvider.execute - function calling', () => {
+  it('tools를 백엔드 요청 body로 전달', async () => {
+    const captured = mockFetch({
+      choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+    const provider = new HttpProvider('test', { ...baseConfig });
+    const tools = [{ type: 'function' as const, function: { name: 'click', description: 'click', parameters: { type: 'object' } } }];
+
+    await provider.execute(makeOptions({ tools, toolChoice: 'auto' }));
+
+    expect(captured.body.tools).toEqual(tools);
+    expect(captured.body.tool_choice).toBe('auto');
+  });
+
+  it('tools 미지정 시 body에 tools 필드 없음', async () => {
+    const captured = mockFetch({
+      choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+    });
+    const provider = new HttpProvider('test', { ...baseConfig });
+
+    await provider.execute(makeOptions({}));
+
+    expect(captured.body.tools).toBeUndefined();
+    expect(captured.body.tool_choice).toBeUndefined();
+  });
+
+  it('멀티턴: assistant tool_calls / tool 메시지의 name·tool_call_id 보존', async () => {
+    const captured = mockFetch({
+      choices: [{ message: { content: 'done' }, finish_reason: 'stop' }],
+    });
+    const provider = new HttpProvider('test', { ...baseConfig });
+
+    await provider.execute(makeOptions({
+      messages: [
+        { role: 'user', content: 'click it' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'click', arguments: '{}' } }],
+        },
+        { role: 'tool', content: 'clicked', name: 'click', tool_call_id: 'call_1' },
+      ],
+    }));
+
+    const msgs = captured.body.messages;
+    expect(msgs[1].tool_calls).toEqual([
+      { id: 'call_1', type: 'function', function: { name: 'click', arguments: '{}' } },
+    ]);
+    expect(msgs[2].name).toBe('click');
+    expect(msgs[2].tool_call_id).toBe('call_1');
+  });
+
+  it('백엔드 응답의 tool_calls를 ExecuteResult.toolCalls로 추출', async () => {
+    mockFetch({
+      choices: [{
+        message: {
+          content: null,
+          tool_calls: [{
+            index: 0,
+            id: 'chatcmpl-tool-abc',
+            type: 'function',
+            function: { name: 'click_element', arguments: '{"selector":"#nav"}' },
+          }],
+        },
+        finish_reason: 'tool_calls',
+      }],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+    const provider = new HttpProvider('test', { ...baseConfig });
+
+    const result = await provider.execute(makeOptions({}));
+
+    expect(result.toolCalls).toEqual([{
+      id: 'chatcmpl-tool-abc',
+      type: 'function',
+      function: { name: 'click_element', arguments: '{"selector":"#nav"}' },
+      index: 0,
+    }]);
+    expect(result.finishReason).toBe('tool_calls');
+  });
+
+  it('tool_calls 없으면 toolCalls 미설정', async () => {
+    mockFetch({
+      choices: [{ message: { content: 'plain' }, finish_reason: 'stop' }],
+    });
+    const provider = new HttpProvider('test', { ...baseConfig });
+
+    const result = await provider.execute(makeOptions({}));
+
+    expect(result.toolCalls).toBeUndefined();
+    expect(result.content).toBe('plain');
+  });
+});
+
+describe('HttpProvider.executeStream - function calling', () => {
+  // SSE 스트림을 ReadableStream으로 모킹
+  function mockStream(lines: string[]) {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const line of lines) controller.enqueue(encoder.encode(line));
+        controller.close();
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { entries: () => [] as [string, string][], get: () => null },
+      body: stream,
+    } as unknown as Response)));
+  }
+
+  it('delta.tool_calls를 tool_use 이벤트로 변환 (index 보존)', async () => {
+    mockStream([
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"click","arguments":"{\\"x\\":1}"}}]}}]}\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n',
+      'data: [DONE]\n',
+    ]);
+    const provider = new HttpProvider('test', { ...baseConfig });
+
+    const events: ProviderEvent[] = [];
+    for await (const ev of provider.executeStream(makeOptions({ stream: true }))) {
+      events.push(ev);
+    }
+
+    const toolEvent = events.find((e) => e.type === 'tool_use');
+    expect(toolEvent).toMatchObject({
+      type: 'tool_use',
+      toolCallId: 'call_1',
+      toolName: 'click',
+      input: '{"x":1}',
+      index: 0,
+    });
+    const doneEvent = events.find((e) => e.type === 'done');
+    expect(doneEvent).toMatchObject({ type: 'done', finishReason: 'tool_use' });
+  });
+});

--- a/packages/server/src/providers/http-provider.ts
+++ b/packages/server/src/providers/http-provider.ts
@@ -97,18 +97,28 @@ export class HttpProvider extends BaseProvider {
 
   // cliproxy가 직접 관리하는 표준 필드. extra_body가 이 키들을 덮어쓰지 못하게 보호.
   private static readonly RESERVED_BODY_KEYS = new Set([
-    'model', 'messages', 'stream', 'max_tokens', 'temperature',
+    'model', 'messages', 'stream', 'max_tokens', 'temperature', 'tools', 'tool_choice',
   ]);
 
   private buildRequestBody(options: ExecuteOptions, stream: boolean): Record<string, unknown> {
     const body: Record<string, unknown> = {
       model: options.model,
-      messages: options.messages.map(m => ({
-        role: m.role,
-        content: m.content,
-      })),
+      // role/content 외에 function calling 필드(name, tool_call_id, tool_calls)도 보존해야
+      // 멀티턴 도구 대화(assistant tool_calls → tool 결과 → 후속 응답)가 백엔드에 온전히 전달됨.
+      messages: options.messages.map(m => {
+        const msg: Record<string, unknown> = { role: m.role, content: m.content };
+        if (m.name !== undefined) msg.name = m.name;
+        if (m.tool_call_id !== undefined) msg.tool_call_id = m.tool_call_id;
+        if (m.tool_calls !== undefined) msg.tool_calls = m.tool_calls;
+        return msg;
+      }),
       stream,
     };
+    // function calling 패스스루: tools가 있을 때만 백엔드로 전달.
+    if (options.tools && options.tools.length > 0) {
+      body.tools = options.tools;
+      if (options.toolChoice !== undefined) body.tool_choice = options.toolChoice;
+    }
     // max_tokens 미지정 시 필드 자체를 생략 → 서버 기본값 사용 (vLLM 등의 max_total_tokens 제한 회피)
     const maxTokens = options.maxTokens ?? this.httpConfig.default_max_tokens;
     if (maxTokens !== undefined) body.max_tokens = maxTokens;
@@ -201,9 +211,23 @@ export class HttpProvider extends BaseProvider {
       const reasoning = rawContent ? rawReasoning : '';
       const usage = responseBody.usage ?? { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
 
+      // function calling: 백엔드가 반환한 tool_calls를 OpenAI 포맷 그대로 보존.
+      const toolCalls = Array.isArray(msg?.tool_calls) && msg.tool_calls.length > 0
+        ? msg.tool_calls.map((tc) => ({
+            id: tc.id ?? '',
+            type: 'function' as const,
+            function: {
+              name: tc.function?.name ?? '',
+              arguments: tc.function?.arguments ?? '',
+            },
+            ...(typeof tc.index === 'number' ? { index: tc.index } : {}),
+          }))
+        : undefined;
+
       return {
         content,
         ...(reasoning ? { reasoning } : {}),
+        ...(toolCalls ? { toolCalls } : {}),
         usage: {
           promptTokens: usage.prompt_tokens ?? 0,
           completionTokens: usage.completion_tokens ?? 0,
@@ -693,7 +717,7 @@ function parseSSELineToEvents(line: string): ProviderEvent[] {
       events.push({ type: 'text_delta', text: delta.content });
     }
 
-    // tool_calls 지원
+    // tool_calls 지원: 병렬 호출 구분을 위해 backend의 index를 보존.
     if (delta?.tool_calls) {
       for (const tc of delta.tool_calls) {
         events.push({
@@ -702,6 +726,7 @@ function parseSSELineToEvents(line: string): ProviderEvent[] {
           toolName: tc.function?.name ?? '',
           input: tc.function?.arguments ?? '',
           isPartial: !tc.id, // id가 없으면 partial delta
+          ...(typeof tc.index === 'number' ? { index: tc.index } : {}),
         });
       }
     }
@@ -716,7 +741,18 @@ function parseSSELineToEvents(line: string): ProviderEvent[] {
 
 interface OpenAIChatCompletionResponse {
   choices?: Array<{
-    message?: { content?: string; reasoning?: string; reasoning_content?: string; role?: string };
+    message?: {
+      content?: string;
+      reasoning?: string;
+      reasoning_content?: string;
+      role?: string;
+      tool_calls?: Array<{
+        index?: number;
+        id?: string;
+        type?: string;
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
     finish_reason?: string;
   }>;
   usage?: {
@@ -770,8 +806,9 @@ type TeiRerankResponse = Array<{ index: number; score: number; text?: string }> 
 
 // === 유틸리티 ===
 
-function mapFinishReason(reason?: string): 'stop' | 'length' | 'error' {
+function mapFinishReason(reason?: string): 'stop' | 'length' | 'tool_calls' | 'error' {
   if (reason === 'length') return 'length';
+  if (reason === 'tool_calls') return 'tool_calls';
   return 'stop';
 }
 

--- a/packages/server/src/routes/v1/chat-completions.ts
+++ b/packages/server/src/routes/v1/chat-completions.ts
@@ -457,6 +457,8 @@ export function registerChatCompletionsRoute(
               reasoningEffort: bodyReasoningEffort ?? route.reasoningEffort,
               providerOverrides: route.providerOverrides,
               extraBody: route.extraBody,
+              tools: body.tools,
+              toolChoice: body.tool_choice,
             });
 
             // text_delta 안의 마커를 splitter로 잘라서 thinking/text_delta로 재분배하는 헬퍼.
@@ -606,6 +608,8 @@ export function registerChatCompletionsRoute(
               reasoningEffort: bodyReasoningEffort ?? route.reasoningEffort,
               providerOverrides: route.providerOverrides,
               extraBody: route.extraBody,
+              tools: body.tools,
+              toolChoice: body.tool_choice,
             }),
           );
 
@@ -626,11 +630,18 @@ export function registerChatCompletionsRoute(
 
           // include_reasoning 우선순위 결정: body > mapping > 기본값(false).
           const effectiveInclude = bodyIncludeReasoning ?? (route.includeReasoning ?? false);
+          const hasToolCalls = !!result.toolCalls && result.toolCalls.length > 0;
           const assistantMessage: ChatCompletionResponse['choices'][0]['message'] = {
             role: 'assistant',
             content,
+            ...(hasToolCalls ? { tool_calls: result.toolCalls } : {}),
             ...(effectiveInclude && reasoning ? { reasoning_content: reasoning } : {}),
           };
+
+          // tool_calls가 있으면 finish_reason을 'tool_calls'로 정규화 (일부 백엔드가 'stop' 반환).
+          const finishReason: ChatCompletionResponse['choices'][0]['finish_reason'] = hasToolCalls
+            ? 'tool_calls'
+            : result.finishReason === 'error' ? 'stop' : result.finishReason;
 
           const response: ChatCompletionResponse = {
             id: requestId,
@@ -640,7 +651,7 @@ export function registerChatCompletionsRoute(
             choices: [{
               index: 0,
               message: assistantMessage,
-              finish_reason: result.finishReason === 'error' ? 'stop' : result.finishReason,
+              finish_reason: finishReason,
             }],
             usage: {
               prompt_tokens: result.usage.promptTokens,

--- a/packages/server/src/utils/stream-transformer.test.ts
+++ b/packages/server/src/utils/stream-transformer.test.ts
@@ -188,6 +188,53 @@ describe('formatAsSSE', () => {
     expect(result).toContain('"finish_reason":"stop"');
     expect(result).toContain('data: [DONE]');
   });
+
+  it('tool_use 이벤트를 delta.tool_calls SSE로 변환', () => {
+    const result = formatAsSSE(
+      { type: 'tool_use', toolCallId: 'call_1', toolName: 'click', input: '{"selector":"#x"}' },
+      'chatcmpl-test-123',
+      'gpt-4',
+    );
+    expect(result).toContain('"tool_calls"');
+    expect(result).toContain('"id":"call_1"');
+    expect(result).toContain('"name":"click"');
+    expect(result).toContain('"type":"function"');
+    expect(result).toContain('"index":0');
+  });
+
+  it('병렬 tool call은 event.index를 보존', () => {
+    const result = formatAsSSE(
+      { type: 'tool_use', toolCallId: 'call_2', toolName: 'scroll', input: '{}', index: 1 },
+      'chatcmpl-test-123',
+      'gpt-4',
+    );
+    expect(result).toContain('"index":1');
+  });
+
+  it('partial tool_use는 id/type/name 생략, arguments delta만 전송', () => {
+    const result = formatAsSSE(
+      { type: 'tool_use', toolCallId: '', toolName: '', input: '{"sel', isPartial: true, index: 0 },
+      'chatcmpl-test-123',
+      'gpt-4',
+    );
+    // SSE data 라인을 파싱하여 tool_call 객체 자체를 검사 (봉투의 id와 구분)
+    const json = JSON.parse(result!.replace(/^data: /, '').trim());
+    const tc = json.choices[0].delta.tool_calls[0];
+    expect(tc.function.arguments).toBe('{"sel');
+    expect(tc.id).toBeUndefined();
+    expect(tc.type).toBeUndefined();
+    expect(tc.function.name).toBeUndefined();
+  });
+
+  it('done(tool_use)는 finish_reason tool_calls로 변환', () => {
+    const result = formatAsSSE(
+      { type: 'done', finishReason: 'tool_use' },
+      'chatcmpl-test-123',
+      'gpt-4',
+    );
+    expect(result).toContain('"finish_reason":"tool_calls"');
+    expect(result).toContain('data: [DONE]');
+  });
 });
 
 describe('createRequestId', () => {

--- a/packages/server/src/utils/stream-transformer.ts
+++ b/packages/server/src/utils/stream-transformer.ts
@@ -386,7 +386,7 @@ function formatProviderEventAsSSE(
     case 'tool_use':
       return makeChunk({
         tool_calls: [{
-          index: 0,
+          index: event.index ?? 0,
           id: event.isPartial ? undefined : event.toolCallId,
           type: event.isPartial ? undefined : 'function',
           function: {
@@ -410,7 +410,8 @@ function formatProviderEventAsSSE(
       return null;
 
     case 'done': {
-      const finishReason = event.finishReason === 'tool_use' ? 'stop'
+      // tool_use → OpenAI 'tool_calls' finish_reason (에이전트가 도구 실행 여부 판단에 사용).
+      const finishReason = event.finishReason === 'tool_use' ? 'tool_calls'
         : event.finishReason === 'length' ? 'length'
         : 'stop';
       return makeChunk({}, finishReason) + 'data: [DONE]\n\n';

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -9,11 +9,43 @@ export interface ChatMessageContentPart {
 
 export type ChatMessageContent = string | ChatMessageContentPart[];
 
+// === Function calling (OpenAI 호환) ===
+
+// 도구(함수) 정의. parameters는 JSON Schema 객체.
+export interface FunctionDefinition {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+}
+
+export interface ChatCompletionTool {
+  type: 'function';
+  function: FunctionDefinition;
+}
+
+// tool_choice: 'none'|'auto'|'required' 또는 특정 함수 강제
+export type ToolChoice =
+  | 'none'
+  | 'auto'
+  | 'required'
+  | { type: 'function'; function: { name: string } };
+
+// 모델이 요청한 도구 호출 (비스트리밍 응답 message.tool_calls / 멀티턴 히스토리).
+// arguments는 JSON 문자열 (OpenAI 스펙).
+export interface ChatMessageToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+  index?: number;
+}
+
 export interface ChatMessage {
   role: 'system' | 'user' | 'assistant' | 'developer' | 'tool';
   content: ChatMessageContent;
   name?: string;            // tool role: 함수/도구 이름
   tool_call_id?: string;    // tool role: 연관된 tool_call ID
+  // assistant role: 모델이 요청한 도구 호출 목록 (멀티턴 도구 대화 시 백엔드로 그대로 전달).
+  tool_calls?: ChatMessageToolCall[];
   // assistant 응답에만 사용: 추론 모델의 thinking/CoT 본문. content와 분리되어 보존됨.
   // OpenAI 공식 스펙 외 비표준 확장 (vLLM/sglang/OpenRouter 등과 호환).
   reasoning_content?: string;
@@ -27,6 +59,9 @@ export interface ChatCompletionRequest {
   temperature?: number;
   top_p?: number;
   stop?: string | string[];
+  // OpenAI 호환 function calling. HTTP provider는 백엔드로 패스스루, CLI provider는 무시.
+  tools?: ChatCompletionTool[];
+  tool_choice?: ToolChoice;
   // OpenAI 호환 추론 수준. 지정 시 model_mapping의 값보다 우선.
   reasoning_effort?: string;
   // 추론 본문(thinking)을 응답에 포함할지. 우선순위: body > mapping > 전역 default(false).
@@ -36,7 +71,7 @@ export interface ChatCompletionRequest {
 export interface ChatCompletionChoice {
   index: number;
   message: ChatMessage;
-  finish_reason: 'stop' | 'length' | 'content_filter' | null;
+  finish_reason: 'stop' | 'length' | 'content_filter' | 'tool_calls' | null;
 }
 
 export interface UsageInfo {
@@ -73,7 +108,7 @@ export interface ChatCompletionChunkDelta {
 export interface ChatCompletionChunkChoice {
   index: number;
   delta: ChatCompletionChunkDelta;
-  finish_reason: 'stop' | 'length' | 'content_filter' | null;
+  finish_reason: 'stop' | 'length' | 'content_filter' | 'tool_calls' | null;
 }
 
 export interface ChatCompletionChunk {

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,6 +1,6 @@
 // Provider 추상화 타입 정의
 
-import type { ChatMessage } from './api.js';
+import type { ChatMessage, ChatCompletionTool, ToolChoice, ChatMessageToolCall } from './api.js';
 
 // 빌트인 프로바이더 (메인 코드에 포함)
 export const BUILTIN_PROVIDERS = ['claude', 'codex', 'copilot', 'gemini', 'agy', 'grok'] as const;
@@ -114,6 +114,9 @@ export interface ExecuteOptions {
   // 백엔드 비표준 필드 패스스루 (HTTP provider 전용). chat_template_kwargs/think/top_k 등.
   // CLI provider는 무시.
   extraBody?: Record<string, unknown>;
+  // OpenAI 호환 function calling. HTTP provider만 백엔드로 전달, CLI provider는 무시.
+  tools?: ChatCompletionTool[];
+  toolChoice?: ToolChoice;
   // Image generation passthrough (OpenAI Images API)
   responseFormat?: 'url' | 'b64_json';
   n?: number;
@@ -200,8 +203,10 @@ export interface ExecuteResult {
   content: string;
   /** 추론 모델의 thinking/CoT 본문. content와 분리되어 보존됨 (있을 때만). */
   reasoning?: string;
+  /** 모델이 요청한 도구 호출 (function calling). 있을 때만 — HTTP provider 비스트리밍. */
+  toolCalls?: ChatMessageToolCall[];
   usage: TokenUsage;
-  finishReason: 'stop' | 'length' | 'error';
+  finishReason: 'stop' | 'length' | 'tool_calls' | 'error';
   meta?: ExecuteMeta;  // provider별 부가 메타데이터 (codex thread_id 등)
 }
 
@@ -218,6 +223,7 @@ export interface ProviderToolUseEvent {
   toolName: string;
   input: string;        // JSON string (완전한 인자 또는 스트리밍 delta)
   isPartial?: boolean;  // true = 스트리밍 JSON delta
+  index?: number;       // 병렬 tool call 구분용 인덱스 (OpenAI delta.tool_calls[].index)
 }
 
 export interface ProviderThinkingEvent {


### PR DESCRIPTION
## Summary
- HTTP provider가 클라이언트 `tools`를 백엔드로 전달하지 않아 function calling이 동작하지 않던 근본 원인 수정
- 비스트리밍 응답에서 백엔드 `tool_calls` 추출 + `finish_reason: tool_calls` 반환
- 멀티턴 도구 대화: 메시지의 `name`/`tool_call_id`/`tool_calls` 보존 (기존엔 `{role, content}`로 깎임)
- 스트리밍 `done(tool_use)`→`finish_reason: tool_calls` 오매핑 수정(기존 `stop`) + 병렬 tool call `index` 보존
- CLI provider(claude/codex/agy/grok)는 `tools` 무시 → 비파괴적

## 근본 원인
`ChatCompletionRequest`에 `tools` 필드 자체가 없어 라우트가 백엔드로 전달하지 않았음. 백엔드(vLLM)는 tools 존재를 몰라 도구 호출 대신 일반 텍스트를 생성 → 모델이 "클릭하겠습니다"라고 말만 함.

## Test plan
- [x] `npm run typecheck` 통과
- [x] `npm run build` 성공 (shared/server/dashboard)
- [x] `npm test` 통과 — 147 passed / 1 skipped(기존)
- [x] 신규 테스트 11종: stream-transformer SSE 직렬화 5 + http-provider fetch-mock 6 (tools 전달, 멀티턴 보존, tool_calls 추출, 스트리밍 index)

## 잔여 검증 (머지 전 권장)
- [ ] 실 백엔드(vLLM qwen3.6) 대상 e2e: `tools` 요청 → `tool_calls` 응답 라운드트립

Closes #13