### PR TITLE
feat(http): tool 미지원 백엔드 에러를 tools_not_supported로 정규화

### DIFF
--- a/packages/server/src/routes/v1/chat-completions.tools-error.test.ts
+++ b/packages/server/src/routes/v1/chat-completions.tools-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { isToolsUnsupportedError } from './chat-completions.js';
+
+describe('isToolsUnsupportedError', () => {
+  it('vLLM 파서 미설정 에러를 감지', () => {
+    const msg = 'a100gemma12 HTTP error: {"message":"\\"auto\\" tool choice requires '
+      + '--enable-auto-tool-choice and --tool-call-parser to be set","type":"BadRequestError","code":400}';
+    expect(isToolsUnsupportedError(msg)).toBe(true);
+  });
+
+  it('"does not support tools" 문구 감지', () => {
+    expect(isToolsUnsupportedError('This model does not support tools.')).toBe(true);
+  });
+
+  it('function calling 미지원 감지', () => {
+    expect(isToolsUnsupportedError('function calling is not supported by this model')).toBe(true);
+  });
+
+  it('tool-call-parser 누락 감지', () => {
+    expect(isToolsUnsupportedError('no tool-call-parser configured')).toBe(true);
+  });
+
+  it('일반 타임아웃은 미감지', () => {
+    expect(isToolsUnsupportedError('provider request timed out after 300000ms')).toBe(false);
+  });
+
+  it('모델 not found는 미감지', () => {
+    expect(isToolsUnsupportedError('Model "x" not found. Check model mappings.')).toBe(false);
+  });
+
+  it('rate limit은 미감지', () => {
+    expect(isToolsUnsupportedError('Rate limit exceeded. Retry after 30 seconds.')).toBe(false);
+  });
+
+  it('인증 실패는 미감지', () => {
+    expect(isToolsUnsupportedError('HTTP error: Invalid API key')).toBe(false);
+  });
+
+  it('빈 문자열/undefined 안전', () => {
+    expect(isToolsUnsupportedError('')).toBe(false);
+    expect(isToolsUnsupportedError(undefined as unknown as string)).toBe(false);
+  });
+});

--- a/packages/server/src/routes/v1/chat-completions.ts
+++ b/packages/server/src/routes/v1/chat-completions.ts
@@ -145,6 +145,17 @@ function normalizeMessageContent(content: unknown): ChatMessageContent {
   return sanitizeString(stringifyUnknown(content));
 }
 
+// 백엔드(vLLM 등) 에러가 function calling(tools) 미지원 신호인지 판별.
+// 백엔드마다 문구가 달라(vLLM: "tool choice requires --enable-auto-tool-choice ...",
+// 일부: "does not support tools") 도구 키워드 + 실패 지시어 조합으로 감지.
+// 클라이언트가 표준 code(tools_not_supported)로 감지해 일반 채팅 폴백할 수 있게 한다.
+export function isToolsUnsupportedError(message: string): boolean {
+  const t = (message || '').toLowerCase();
+  const mentionsTools = /tool[_ -]?call|tool[_ -]?choice|tool[_ -]?parser|tool[_ -]?use|enable-auto-tool-choice|function[_ ]?call|\btools?\b/.test(t);
+  const failure = /not\s+support|unsupport|requires|must be set|to be set|no .*parser|not enabled|disabled|invalid/.test(t);
+  return mentionsTools && failure;
+}
+
 // CLI 에러 메시지에서 내부 정보 제거 (파일 경로, 스택 트레이스 등)
 // 클라이언트에 노출되는 에러 응답에만 적용 — 내부 로그는 원본 유지
 function sanitizeProviderError(message: string): string {
@@ -761,6 +772,20 @@ export function registerChatCompletionsRoute(
           deps.healthChecker.onRequestFailure(route.provider);
           continue;
         }
+      }
+
+      // 모든 provider 실패 + 마지막 에러가 도구 미지원이면 502 대신 400 + tools_not_supported.
+      // 클라이언트가 안정적으로 감지해 tools 없이 일반 채팅으로 폴백할 수 있게 한다.
+      if (body.tools && body.tools.length > 0 && lastError && isToolsUnsupportedError(lastError.message)) {
+        return reply.status(400).send({
+          error: {
+            message: `Model "${body.model}" does not support tool calling. The backend rejected the 'tools' request. `
+              + `If self-hosting vLLM, start it with --enable-auto-tool-choice and a matching --tool-call-parser.`,
+            type: 'invalid_request_error',
+            param: 'tools',
+            code: 'tools_not_supported',
+          },
+        });
       }
 
       // ADD-03: 타임아웃 여부에 따라 504/502 구분


### PR DESCRIPTION
## Summary
- 백엔드(vLLM 등)가 tool 파서 없이 떠 400을 반환할 때, 기존 502 "All providers failed" 대신 **400 + code `tools_not_supported`**로 정규화
- 클라이언트(크롬 확장 등)가 백엔드별 제각각 문구를 문자열 매칭하지 않고 표준 코드 하나로 "도구 미지원"을 감지 → 일반 채팅 폴백 가능
- 폴백 루프 의미는 유지(다른 provider가 tools 지원하면 그대로 성공). 모든 provider가 도구 미지원으로 실패한 경우에만 최종 응답을 400으로 교체
- 에러 메시지에 조치 힌트(`--enable-auto-tool-choice` + `--tool-call-parser`) 포함

## 배경
실제 사례: gemma-4-12b 백엔드가 `"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set` 반환 → 확장에서 일반 채팅까지 502로 깨짐. 감지·폴백의 본체는 클라이언트가 담당하고, 프록시는 감지 견고성을 위한 표준 코드를 제공.

## Test plan
- [x] `npm run typecheck` 통과
- [x] `npm run build` 성공
- [x] `npm test` 통과 — 156 passed / 1 skipped(기존)
- [x] 신규 테스트 9종: isToolsUnsupportedError (vLLM 실제 문구, does not support tools, function calling, 타임아웃/rate limit/인증 오탐 방지)

Closes #15