### PR TITLE
fix: prevent streaming resource leaks (#20)

### DIFF
--- a/packages/server/src/providers/http-provider.test.ts
+++ b/packages/server/src/providers/http-provider.test.ts
@@ -177,4 +177,36 @@ describe('HttpProvider.executeStream - function calling', () => {
     const doneEvent = events.find((e) => e.type === 'done');
     expect(doneEvent).toMatchObject({ type: 'done', finishReason: 'tool_use' });
   });
+
+  it("'done' 수신 후 reader.cancel()로 백엔드 스트림을 취소하고 잔여 바이트를 방출하지 않는다", async () => {
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n'));
+        controller.enqueue(encoder.encode('data: [DONE]\n'));
+        // [DONE] 이후 추가 바이트: generator가 done에서 return하면 소비되면 안 됨.
+        // close()를 호출하지 않으므로 명시적 cancel()이 없으면 스트림이 열린 채 유지된다.
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"leak"}}]}\n'));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { entries: () => [] as [string, string][], get: () => null },
+      body: stream,
+    } as unknown as Response)));
+
+    const provider = new HttpProvider('test', { ...baseConfig });
+    const events: ProviderEvent[] = [];
+    for await (const ev of provider.executeStream(makeOptions({ stream: true }))) {
+      events.push(ev);
+    }
+
+    expect(cancelled).toBe(true);
+    expect(events.some((e) => e.type === 'text_delta' && e.text === 'leak')).toBe(false);
+  });
 });

--- a/packages/server/src/providers/http-provider.ts
+++ b/packages/server/src/providers/http-provider.ts
@@ -344,7 +344,10 @@ export class HttpProvider extends BaseProvider {
           for (const event of events) yield event;
         }
       } finally {
-        reader.releaseLock();
+        // SSE 'done' 수신으로 조기 return하거나 소비자가 generator를 조기 종료한 경우,
+        // releaseLock만으로는 fetch body 스트림이 취소되지 않아 백엔드 소켓이 timeout까지 잔류한다.
+        // cancel()은 스트림을 명시적으로 닫고 lock도 해제한다(정상 완료 시엔 no-op).
+        await reader.cancel().catch(() => {});
       }
     } finally {
       clearTimeout(timeoutId);

--- a/packages/server/src/routes/v1/chat-completions.ts
+++ b/packages/server/src/routes/v1/chat-completions.ts
@@ -413,8 +413,12 @@ export function registerChatCompletionsRoute(
           if (body.stream) {
             // 클라이언트 연결 끊김 감지용 AbortController (큐 외부에서 생성하여 대기 중에도 감지)
             const abortController = new AbortController();
-            request.raw.on('close', () => abortController.abort());
+            // 이른 스트리밍 실패로 폴백할 때 close 리스너가 누적되지 않도록 named handler로 등록하고
+            // 스트리밍 종료(성공/에러/예외) 시 finally에서 반드시 제거한다.
+            const onClientClose = () => abortController.abort();
+            request.raw.once('close', onClientClose);
 
+            try {
             // 스트리밍도 큐를 통해 동시성 제한 적용 (BUG-01 수정)
             await deps.queue.enqueue(route.provider, async () => {
             // 큐 대기 중 클라이언트가 이미 연결을 끊었으면 조기 종료
@@ -603,6 +607,9 @@ export function registerChatCompletionsRoute(
             }); // queue.enqueue 끝
 
             return;
+            } finally {
+              request.raw.removeListener('close', onClientClose);
+            }
           }
 
           // Non-streaming 응답


### PR DESCRIPTION
## Summary
스트리밍 경로 HIGH 리소스 누수 2건 수정.
- **http-provider**: SSE `done` 조기 return 시 `reader.cancel()` 호출로 백엔드 소켓 즉시 해제 (기존 `releaseLock`만으로는 timeout까지 잔류)
- **chat-completions**: `close` 리스너를 `once` + `try/finally removeListener`로 정리 (폴백 시 누적 방지)

## Test plan
- [x] reader.cancel 회귀 테스트 추가 — mutation 검증(fix 제거 시 실패) 완료
- [x] `npx vitest run` → 157 passed / 1 skipped (기준선 +1 신규, flip 없음)
- [x] `tsc -b` 통과

Closes #20