### PR TITLE
fix: rate limit 폴백 중복 카운트 방지 (#22)

### DIFF
--- a/packages/server/src/middleware/rate-limiter.test.ts
+++ b/packages/server/src/middleware/rate-limiter.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import type { RateLimitConfig } from '@star-cliproxy/shared';
+import { RateLimiter } from './rate-limiter.js';
+
+// getDatabase()는 테스트 환경에서 미초기화 상태이며 loadFromDb/flushToDb가
+// 내부 try-catch로 모든 에러를 삼키므로 인메모리 카운터만으로 동작한다.
+
+function makeConfig(overrides?: Partial<RateLimitConfig>): RateLimitConfig {
+  return {
+    global: { rpm: 1000, rpd: 10000 },
+    perProvider: {},
+    ...overrides,
+  };
+}
+
+const limiters: RateLimiter[] = [];
+function newLimiter(config: RateLimitConfig): RateLimiter {
+  const rl = new RateLimiter(config);
+  limiters.push(rl);
+  return rl;
+}
+
+afterEach(async () => {
+  // cleanup 타이머 정리 (프로세스 유지 방지)
+  await Promise.all(limiters.splice(0).map((rl) => rl.destroy()));
+});
+
+describe('RateLimiter - 폴백 중복 카운트 방지 (HIGH 버그 회귀)', () => {
+  it('checkGlobalAndKey + checkProvider 분리: 폴백으로 프로바이더를 여러 번 시도해도 글로벌은 1회만 차감', () => {
+    // 글로벌 RPM을 2로 제한. 한 요청이 2개 프로바이더로 폴백하는 상황을 시뮬레이션.
+    const rl = newLimiter(makeConfig({ global: { rpm: 2, rpd: 100 } }));
+
+    // 요청당 글로벌은 1회만 차감
+    expect(rl.checkGlobalAndKey('key1').allowed).toBe(true);
+    // 같은 요청 내에서 프로바이더 A, B를 시도 (글로벌 재차감 없음)
+    expect(rl.checkProvider('providerA').allowed).toBe(true);
+    expect(rl.checkProvider('providerB').allowed).toBe(true);
+
+    // 글로벌은 아직 1만 소진 → 두 번째 요청도 통과해야 함
+    expect(rl.checkGlobalAndKey('key1').allowed).toBe(true);
+    // 세 번째 요청은 글로벌 RPM(2) 초과 → 차단
+    const third = rl.checkGlobalAndKey('key1');
+    expect(third.allowed).toBe(false);
+    expect(third.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it('레거시 checkAndIncrement는 폴백 시 글로벌을 매번 차감(중복) — 분리 메서드로 교체된 이유', () => {
+    const rl = newLimiter(makeConfig({ global: { rpm: 2, rpd: 100 } }));
+    // checkAndIncrement는 글로벌+프로바이더를 한 번에 차감하므로
+    // 폴백 루프 안에서 2회 호출하면 글로벌이 2 소진된다.
+    expect(rl.checkAndIncrement('key1', 'providerA').allowed).toBe(true);
+    expect(rl.checkAndIncrement('key1', 'providerB').allowed).toBe(true);
+    // 글로벌 RPM(2) 이미 소진 → 다음 요청 차단 (단일 요청이 2슬롯을 먹은 셈)
+    expect(rl.checkGlobalAndKey('key1').allowed).toBe(false);
+  });
+});
+
+describe('RateLimiter - checkProvider', () => {
+  it('프로바이더 한도가 없으면 항상 allowed', () => {
+    const rl = newLimiter(makeConfig());
+    for (let i = 0; i < 100; i++) {
+      expect(rl.checkProvider('noLimit').allowed).toBe(true);
+    }
+  });
+
+  it('프로바이더 RPM 한도 초과 시 차단 + retryAfter', () => {
+    const rl = newLimiter(makeConfig({ perProvider: { gemini: { rpm: 2 } } }));
+    expect(rl.checkProvider('gemini').allowed).toBe(true);
+    expect(rl.checkProvider('gemini').allowed).toBe(true);
+    const blocked = rl.checkProvider('gemini');
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+    // 다른 프로바이더는 독립 카운터
+    expect(rl.checkProvider('other').allowed).toBe(true);
+  });
+});
+
+describe('RateLimiter - checkGlobalAndKey', () => {
+  it('글로벌 RPD 초과 시 글로벌 RPM 롤백 (원자성)', () => {
+    // RPM은 넉넉, RPD를 1로 제한
+    const rl = newLimiter(makeConfig({ global: { rpm: 100, rpd: 1 } }));
+    expect(rl.checkGlobalAndKey('key1').allowed).toBe(true);
+    // 두 번째: RPD(1) 초과 → 차단, 이때 RPM은 롤백되어야 함
+    expect(rl.checkGlobalAndKey('key1').allowed).toBe(false);
+  });
+
+  it('API 키별 RPM 한도 적용 + 키별 독립', () => {
+    const rl = newLimiter(makeConfig());
+    expect(rl.checkGlobalAndKey('key1', { rpm: 1 }).allowed).toBe(true);
+    expect(rl.checkGlobalAndKey('key1', { rpm: 1 }).allowed).toBe(false); // key1 초과
+    expect(rl.checkGlobalAndKey('key2', { rpm: 1 }).allowed).toBe(true);  // key2는 독립
+  });
+
+  it('키 RPM 초과 시 글로벌 카운터 롤백', () => {
+    const rl = newLimiter(makeConfig({ global: { rpm: 5, rpd: 5 } }));
+    // key1: rpm 1 한도. 1회 통과 후 2회차 차단되며 글로벌은 롤백.
+    expect(rl.checkGlobalAndKey('key1', { rpm: 1 }).allowed).toBe(true);  // global=1
+    expect(rl.checkGlobalAndKey('key1', { rpm: 1 }).allowed).toBe(false); // key 초과, global 롤백
+    // 글로벌이 롤백되었으므로 다른 키로 4회 더 통과 가능 (총 global 한도 5)
+    for (let i = 0; i < 4; i++) {
+      expect(rl.checkGlobalAndKey(`k${i}`).allowed).toBe(true);
+    }
+    expect(rl.checkGlobalAndKey('kX').allowed).toBe(false); // 이제 global 5 소진
+  });
+});

--- a/packages/server/src/middleware/rate-limiter.ts
+++ b/packages/server/src/middleware/rate-limiter.ts
@@ -37,10 +37,31 @@ export class RateLimiter {
     await this.flushToDb();
   }
 
-  // 요청 가능 여부 확인 + 카운터 원자적 증가
+  // 요청 가능 여부 확인 + 카운터 원자적 증가 (글로벌/키 + 프로바이더 한 번에).
+  // 폴백 루프가 없는 단일 시도 경로용. 폴백이 있는 라우트는
+  // checkGlobalAndKey(루프 밖 1회) + checkProvider(루프 안)를 분리 호출할 것.
   checkAndIncrement(
     apiKeyId: string,
     provider: string,
+    keyLimits?: { rpm?: number | null; rpd?: number | null },
+  ): { allowed: boolean; retryAfterSeconds?: number } {
+    const gk = this.checkGlobalAndKey(apiKeyId, keyLimits);
+    if (!gk.allowed) return gk;
+
+    const prov = this.checkProvider(provider);
+    if (!prov.allowed) {
+      // 프로바이더 한도 실패 시 이미 증가된 글로벌/키 카운터를 되돌려 원자성 유지
+      this.rollbackGlobalAndKey(apiKeyId, keyLimits);
+      return prov;
+    }
+
+    return { allowed: true };
+  }
+
+  // 글로벌 + API 키 단위 한도 확인·증가. 요청당 1회(폴백 루프 진입 전)만 호출해야 한다.
+  // 폴백으로 여러 프로바이더를 시도해도 글로벌/키 카운터가 중복 차감되지 않도록 분리됨.
+  checkGlobalAndKey(
+    apiKeyId: string,
     keyLimits?: { rpm?: number | null; rpd?: number | null },
   ): { allowed: boolean; retryAfterSeconds?: number } {
     const now = Date.now();
@@ -56,41 +77,48 @@ export class RateLimiter {
       return globalRpd;
     }
 
-    // 3. Provider별 RPM
-    const providerLimit = this.config.perProvider[provider]?.rpm;
-    if (providerLimit) {
-      const providerRpm = this.tryIncrement(`provider:${provider}:rpm`, providerLimit, now, 60_000, this.minuteCounters);
-      if (!providerRpm.allowed) {
-        this.rollback('global:rpm', this.minuteCounters);
-        this.rollback('global:rpd', this.dayCounters);
-        return providerRpm;
-      }
-    }
-
-    // 4. API 키별 RPM
+    // 3. API 키별 RPM
     if (keyLimits?.rpm) {
       const keyRpm = this.tryIncrement(`key:${apiKeyId}:rpm`, keyLimits.rpm, now, 60_000, this.minuteCounters);
       if (!keyRpm.allowed) {
         this.rollback('global:rpm', this.minuteCounters);
         this.rollback('global:rpd', this.dayCounters);
-        if (providerLimit) this.rollback(`provider:${provider}:rpm`, this.minuteCounters);
         return keyRpm;
       }
     }
 
-    // 5. API 키별 RPD
+    // 4. API 키별 RPD
     if (keyLimits?.rpd) {
       const keyRpd = this.tryIncrement(`key:${apiKeyId}:rpd`, keyLimits.rpd, now, 86_400_000, this.dayCounters);
       if (!keyRpd.allowed) {
         this.rollback('global:rpm', this.minuteCounters);
         this.rollback('global:rpd', this.dayCounters);
-        if (providerLimit) this.rollback(`provider:${provider}:rpm`, this.minuteCounters);
         if (keyLimits.rpm) this.rollback(`key:${apiKeyId}:rpm`, this.minuteCounters);
         return keyRpd;
       }
     }
 
     return { allowed: true };
+  }
+
+  // 프로바이더 단위 RPM 한도 확인·증가. 폴백 루프 안에서 프로바이더별로 호출한다.
+  // 프로바이더 한도가 없으면 항상 allowed.
+  checkProvider(provider: string): { allowed: boolean; retryAfterSeconds?: number } {
+    const providerLimit = this.config.perProvider[provider]?.rpm;
+    if (!providerLimit) return { allowed: true };
+    const now = Date.now();
+    return this.tryIncrement(`provider:${provider}:rpm`, providerLimit, now, 60_000, this.minuteCounters);
+  }
+
+  // 글로벌/키 카운터 일괄 롤백 (checkGlobalAndKey로 증가시킨 뒤 후속 단계 실패 시)
+  private rollbackGlobalAndKey(
+    apiKeyId: string,
+    keyLimits?: { rpm?: number | null; rpd?: number | null },
+  ): void {
+    this.rollback('global:rpm', this.minuteCounters);
+    this.rollback('global:rpd', this.dayCounters);
+    if (keyLimits?.rpm) this.rollback(`key:${apiKeyId}:rpm`, this.minuteCounters);
+    if (keyLimits?.rpd) this.rollback(`key:${apiKeyId}:rpd`, this.dayCounters);
   }
 
   // 원자적 check + increment: 한도 내이면 즉시 카운터 증가

--- a/packages/server/src/routes/v1/audio-speech.ts
+++ b/packages/server/src/routes/v1/audio-speech.ts
@@ -100,7 +100,22 @@ export function registerAudioSpeechRoute(
       const apiKeyId = (request as unknown as { apiKeyId?: string }).apiKeyId;
       const keyLimits = (request as unknown as { apiKeyRateLimits?: { rpm?: number | null; rpd?: number | null } }).apiKeyRateLimits;
 
+      // === 레이트 리밋: 글로벌/키 단위는 요청당 1회만 차감 (폴백 루프 진입 전) ===
+      const gkResult = deps.rateLimiter.checkGlobalAndKey(apiKeyId ?? 'anonymous', keyLimits);
+      if (!gkResult.allowed) {
+        reply.header('Retry-After', String(gkResult.retryAfterSeconds ?? 30));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${gkResult.retryAfterSeconds} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
+      }
+
       let lastError: Error | null = null;
+      let rateLimitRetryAfter: number | null = null;
 
       for (const route of routes) {
         const healthy = await deps.healthChecker.isHealthy(route.provider);
@@ -109,22 +124,12 @@ export function registerAudioSpeechRoute(
           continue;
         }
 
-        const rateResult = deps.rateLimiter.checkAndIncrement(
-          apiKeyId ?? 'anonymous',
-          route.provider,
-          keyLimits,
-        );
-
-        if (!rateResult.allowed) {
-          reply.header('Retry-After', String(rateResult.retryAfterSeconds ?? 30));
-          return reply.status(429).send({
-            error: {
-              message: `Rate limit exceeded. Retry after ${rateResult.retryAfterSeconds} seconds.`,
-              type: 'rate_limit_error',
-              param: null,
-              code: 'rate_limit_exceeded',
-            },
-          });
+        // 프로바이더 단위 한도는 시도하는 프로바이더별로 차감. 초과 시 다음 프로바이더로 폴백.
+        const provRate = deps.rateLimiter.checkProvider(route.provider);
+        if (!provRate.allowed) {
+          rateLimitRetryAfter = provRate.retryAfterSeconds ?? 30;
+          lastError = new Error(`Provider ${route.provider} rate limit exceeded`);
+          continue;
         }
 
         const provider = deps.registry.get(route.provider);
@@ -251,6 +256,19 @@ export function registerAudioSpeechRoute(
           deps.healthChecker.onRequestFailure(route.provider);
           continue;
         }
+      }
+
+      // 모든 provider가 프로바이더 단위 한도로 소진되었으면 502 대신 429 반환.
+      if (rateLimitRetryAfter !== null) {
+        reply.header('Retry-After', String(rateLimitRetryAfter));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${rateLimitRetryAfter} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
       }
 
       const isTimeout = lastError?.message.includes('timed out') ?? false;

--- a/packages/server/src/routes/v1/chat-completions.ts
+++ b/packages/server/src/routes/v1/chat-completions.ts
@@ -342,9 +342,25 @@ export function registerChatCompletionsRoute(
         }
       }
 
+      // === 레이트 리밋: 글로벌/키 단위는 요청당 1회만 차감 (폴백 루프 진입 전) ===
+      const gkResult = deps.rateLimiter.checkGlobalAndKey(apiKeyId ?? 'anonymous', keyLimits);
+      if (!gkResult.allowed) {
+        reply.header('Retry-After', String(gkResult.retryAfterSeconds ?? 30));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${gkResult.retryAfterSeconds} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
+      }
+
       // === 폴백 루프 ===
 
       let lastError: Error | null = null;
+      // 프로바이더 단위 한도로 폴백된 경우의 retry-after (모든 프로바이더 소진 시 429 반환에 사용)
+      let rateLimitRetryAfter: number | null = null;
 
       for (const route of routes) {
         const healthy = await deps.healthChecker.isHealthy(route.provider);
@@ -353,22 +369,12 @@ export function registerChatCompletionsRoute(
           continue;
         }
 
-        const rateResult = deps.rateLimiter.checkAndIncrement(
-          apiKeyId ?? 'anonymous',
-          route.provider,
-          keyLimits,
-        );
-
-        if (!rateResult.allowed) {
-          reply.header('Retry-After', String(rateResult.retryAfterSeconds ?? 30));
-          return reply.status(429).send({
-            error: {
-              message: `Rate limit exceeded. Retry after ${rateResult.retryAfterSeconds} seconds.`,
-              type: 'rate_limit_error',
-              param: null,
-              code: 'rate_limit_exceeded',
-            },
-          });
+        // 프로바이더 단위 한도는 시도하는 프로바이더별로 차감. 초과 시 다음 프로바이더로 폴백.
+        const provRate = deps.rateLimiter.checkProvider(route.provider);
+        if (!provRate.allowed) {
+          rateLimitRetryAfter = provRate.retryAfterSeconds ?? 30;
+          lastError = new Error(`Provider ${route.provider} rate limit exceeded`);
+          continue;
         }
 
         const provider = deps.registry.get(route.provider);
@@ -772,6 +778,19 @@ export function registerChatCompletionsRoute(
           deps.healthChecker.onRequestFailure(route.provider);
           continue;
         }
+      }
+
+      // 모든 provider가 프로바이더 단위 한도로 소진되었으면 502 대신 429 반환.
+      if (rateLimitRetryAfter !== null) {
+        reply.header('Retry-After', String(rateLimitRetryAfter));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${rateLimitRetryAfter} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
       }
 
       // 모든 provider 실패 + 마지막 에러가 도구 미지원이면 502 대신 400 + tools_not_supported.

--- a/packages/server/src/routes/v1/embeddings.ts
+++ b/packages/server/src/routes/v1/embeddings.ts
@@ -81,7 +81,22 @@ export function registerEmbeddingsRoute(
       const apiKeyId = (request as unknown as { apiKeyId?: string }).apiKeyId;
       const keyLimits = (request as unknown as { apiKeyRateLimits?: { rpm?: number | null; rpd?: number | null } }).apiKeyRateLimits;
 
+      // === 레이트 리밋: 글로벌/키 단위는 요청당 1회만 차감 (폴백 루프 진입 전) ===
+      const gkResult = deps.rateLimiter.checkGlobalAndKey(apiKeyId ?? 'anonymous', keyLimits);
+      if (!gkResult.allowed) {
+        reply.header('Retry-After', String(gkResult.retryAfterSeconds ?? 30));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${gkResult.retryAfterSeconds} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
+      }
+
       let lastError: Error | null = null;
+      let rateLimitRetryAfter: number | null = null;
 
       for (const route of routes) {
         const healthy = await deps.healthChecker.isHealthy(route.provider);
@@ -90,22 +105,12 @@ export function registerEmbeddingsRoute(
           continue;
         }
 
-        const rateResult = deps.rateLimiter.checkAndIncrement(
-          apiKeyId ?? 'anonymous',
-          route.provider,
-          keyLimits,
-        );
-
-        if (!rateResult.allowed) {
-          reply.header('Retry-After', String(rateResult.retryAfterSeconds ?? 30));
-          return reply.status(429).send({
-            error: {
-              message: `Rate limit exceeded. Retry after ${rateResult.retryAfterSeconds} seconds.`,
-              type: 'rate_limit_error',
-              param: null,
-              code: 'rate_limit_exceeded',
-            },
-          });
+        // 프로바이더 단위 한도는 시도하는 프로바이더별로 차감. 초과 시 다음 프로바이더로 폴백.
+        const provRate = deps.rateLimiter.checkProvider(route.provider);
+        if (!provRate.allowed) {
+          rateLimitRetryAfter = provRate.retryAfterSeconds ?? 30;
+          lastError = new Error(`Provider ${route.provider} rate limit exceeded`);
+          continue;
         }
 
         const provider = deps.registry.get(route.provider);
@@ -251,6 +256,19 @@ export function registerEmbeddingsRoute(
           deps.healthChecker.onRequestFailure(route.provider);
           continue;
         }
+      }
+
+      // 모든 provider가 프로바이더 단위 한도로 소진되었으면 502 대신 429 반환.
+      if (rateLimitRetryAfter !== null) {
+        reply.header('Retry-After', String(rateLimitRetryAfter));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${rateLimitRetryAfter} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
       }
 
       const isTimeout = lastError?.message.includes('timed out') ?? false;

--- a/packages/server/src/routes/v1/images-generations.ts
+++ b/packages/server/src/routes/v1/images-generations.ts
@@ -69,7 +69,22 @@ export function registerImageGenerationsRoute(
       const apiKeyId = (request as unknown as { apiKeyId?: string }).apiKeyId;
       const keyLimits = (request as unknown as { apiKeyRateLimits?: { rpm?: number | null; rpd?: number | null } }).apiKeyRateLimits;
 
+      // === 레이트 리밋: 글로벌/키 단위는 요청당 1회만 차감 (폴백 루프 진입 전) ===
+      const gkResult = deps.rateLimiter.checkGlobalAndKey(apiKeyId ?? 'anonymous', keyLimits);
+      if (!gkResult.allowed) {
+        reply.header('Retry-After', String(gkResult.retryAfterSeconds ?? 30));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${gkResult.retryAfterSeconds} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
+      }
+
       let lastError: Error | null = null;
+      let rateLimitRetryAfter: number | null = null;
 
       for (const route of routes) {
         const healthy = await deps.healthChecker.isHealthy(route.provider);
@@ -78,22 +93,12 @@ export function registerImageGenerationsRoute(
           continue;
         }
 
-        const rateResult = deps.rateLimiter.checkAndIncrement(
-          apiKeyId ?? 'anonymous',
-          route.provider,
-          keyLimits,
-        );
-
-        if (!rateResult.allowed) {
-          reply.header('Retry-After', String(rateResult.retryAfterSeconds ?? 30));
-          return reply.status(429).send({
-            error: {
-              message: `Rate limit exceeded. Retry after ${rateResult.retryAfterSeconds} seconds.`,
-              type: 'rate_limit_error',
-              param: null,
-              code: 'rate_limit_exceeded',
-            },
-          });
+        // 프로바이더 단위 한도는 시도하는 프로바이더별로 차감. 초과 시 다음 프로바이더로 폴백.
+        const provRate = deps.rateLimiter.checkProvider(route.provider);
+        if (!provRate.allowed) {
+          rateLimitRetryAfter = provRate.retryAfterSeconds ?? 30;
+          lastError = new Error(`Provider ${route.provider} rate limit exceeded`);
+          continue;
         }
 
         const provider = deps.registry.get(route.provider);
@@ -230,6 +235,19 @@ export function registerImageGenerationsRoute(
           deps.healthChecker.onRequestFailure(route.provider);
           continue;
         }
+      }
+
+      // 모든 provider가 프로바이더 단위 한도로 소진되었으면 502 대신 429 반환.
+      if (rateLimitRetryAfter !== null) {
+        reply.header('Retry-After', String(rateLimitRetryAfter));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${rateLimitRetryAfter} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
       }
 
       const isTimeout = lastError?.message.includes('timed out') ?? false;

--- a/packages/server/src/routes/v1/messages.ts
+++ b/packages/server/src/routes/v1/messages.ts
@@ -279,9 +279,17 @@ export function registerMessagesRoute(
         }
       }
 
+      // === 레이트 리밋: 글로벌/키 단위는 요청당 1회만 차감 (폴백 루프 진입 전) ===
+      const gkResult = deps.rateLimiter.checkGlobalAndKey(apiKeyId ?? 'anonymous', keyLimits);
+      if (!gkResult.allowed) {
+        reply.header('Retry-After', String(gkResult.retryAfterSeconds ?? 30));
+        return reply.status(429).send(makeAnthropicError('rate_limit_error', `Rate limit exceeded. Retry after ${gkResult.retryAfterSeconds} seconds.`));
+      }
+
       // === 폴백 루프 ===
 
       let lastError: Error | null = null;
+      let rateLimitRetryAfter: number | null = null;
 
       for (const route of routes) {
         const healthy = await deps.healthChecker.isHealthy(route.provider);
@@ -290,15 +298,12 @@ export function registerMessagesRoute(
           continue;
         }
 
-        const rateResult = deps.rateLimiter.checkAndIncrement(
-          apiKeyId ?? 'anonymous',
-          route.provider,
-          keyLimits,
-        );
-
-        if (!rateResult.allowed) {
-          reply.header('Retry-After', String(rateResult.retryAfterSeconds ?? 30));
-          return reply.status(429).send(makeAnthropicError('rate_limit_error', `Rate limit exceeded. Retry after ${rateResult.retryAfterSeconds} seconds.`));
+        // 프로바이더 단위 한도는 시도하는 프로바이더별로 차감. 초과 시 다음 프로바이더로 폴백.
+        const provRate = deps.rateLimiter.checkProvider(route.provider);
+        if (!provRate.allowed) {
+          rateLimitRetryAfter = provRate.retryAfterSeconds ?? 30;
+          lastError = new Error(`Provider ${route.provider} rate limit exceeded`);
+          continue;
         }
 
         const provider = deps.registry.get(route.provider);
@@ -693,6 +698,12 @@ export function registerMessagesRoute(
           deps.healthChecker.onRequestFailure(route.provider);
           continue;
         }
+      }
+
+      // 모든 provider가 프로바이더 단위 한도로 소진되었으면 502 대신 429 반환.
+      if (rateLimitRetryAfter !== null) {
+        reply.header('Retry-After', String(rateLimitRetryAfter));
+        return reply.status(429).send(makeAnthropicError('rate_limit_error', `Rate limit exceeded. Retry after ${rateLimitRetryAfter} seconds.`));
       }
 
       // 모든 프로바이더 실패

--- a/packages/server/src/routes/v1/rerank.ts
+++ b/packages/server/src/routes/v1/rerank.ts
@@ -88,7 +88,22 @@ export function registerRerankRoute(
       const apiKeyId = (request as unknown as { apiKeyId?: string }).apiKeyId;
       const keyLimits = (request as unknown as { apiKeyRateLimits?: { rpm?: number | null; rpd?: number | null } }).apiKeyRateLimits;
 
+      // === 레이트 리밋: 글로벌/키 단위는 요청당 1회만 차감 (폴백 루프 진입 전) ===
+      const gkResult = deps.rateLimiter.checkGlobalAndKey(apiKeyId ?? 'anonymous', keyLimits);
+      if (!gkResult.allowed) {
+        reply.header('Retry-After', String(gkResult.retryAfterSeconds ?? 30));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${gkResult.retryAfterSeconds} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
+      }
+
       let lastError: Error | null = null;
+      let rateLimitRetryAfter: number | null = null;
 
       for (const route of routes) {
         const healthy = await deps.healthChecker.isHealthy(route.provider);
@@ -97,22 +112,12 @@ export function registerRerankRoute(
           continue;
         }
 
-        const rateResult = deps.rateLimiter.checkAndIncrement(
-          apiKeyId ?? 'anonymous',
-          route.provider,
-          keyLimits,
-        );
-
-        if (!rateResult.allowed) {
-          reply.header('Retry-After', String(rateResult.retryAfterSeconds ?? 30));
-          return reply.status(429).send({
-            error: {
-              message: `Rate limit exceeded. Retry after ${rateResult.retryAfterSeconds} seconds.`,
-              type: 'rate_limit_error',
-              param: null,
-              code: 'rate_limit_exceeded',
-            },
-          });
+        // 프로바이더 단위 한도는 시도하는 프로바이더별로 차감. 초과 시 다음 프로바이더로 폴백.
+        const provRate = deps.rateLimiter.checkProvider(route.provider);
+        if (!provRate.allowed) {
+          rateLimitRetryAfter = provRate.retryAfterSeconds ?? 30;
+          lastError = new Error(`Provider ${route.provider} rate limit exceeded`);
+          continue;
         }
 
         const provider = deps.registry.get(route.provider);
@@ -258,6 +263,19 @@ export function registerRerankRoute(
           deps.healthChecker.onRequestFailure(route.provider);
           continue;
         }
+      }
+
+      // 모든 provider가 프로바이더 단위 한도로 소진되었으면 502 대신 429 반환.
+      if (rateLimitRetryAfter !== null) {
+        reply.header('Retry-After', String(rateLimitRetryAfter));
+        return reply.status(429).send({
+          error: {
+            message: `Rate limit exceeded. Retry after ${rateLimitRetryAfter} seconds.`,
+            type: 'rate_limit_error',
+            param: null,
+            code: 'rate_limit_exceeded',
+          },
+        });
       }
 
       const isTimeout = lastError?.message.includes('timed out') ?? false;


### PR DESCRIPTION
## Summary
폴백 루프 안에서 `checkAndIncrement`가 호출되어 프로바이더 폴백마다 글로벌 RPM/RPD·키 카운터가 중복 차감되던 HIGH 버그 수정.
- rate-limiter를 `checkGlobalAndKey`(요청당 1회) + `checkProvider`(프로바이더별)로 분리, `rollbackGlobalAndKey`로 원자성 유지
- 6개 v1 라우트(chat-completions/messages/embeddings/audio-speech/images-generations/rerank)에 적용: 글로벌/키는 루프 밖 1회, 프로바이더 한도는 루프 안에서 차감하되 초과 시 폴백, 전부 소진 시 429
- 레거시 `checkAndIncrement`는 두 메서드를 delegate (하위 호환)

## Test plan
- [x] rate-limiter 단위 테스트 7건 추가 (폴백 중복 카운트 회귀 테스트 포함)
- [x] `npx vitest run` → 163 passed / 1 skipped (기준선 +7 신규, flip 없음)
- [x] `tsc -b` 통과, `npm run build` 성공

## 동작 변경 (의도적)
- 프로바이더 단위 한도 초과 시 즉시 429 대신 **다음 프로바이더로 폴백** (폴백 라우트의 본래 취지에 부합). 모든 프로바이더가 한도 소진 시 429 반환.

Closes #22