### PR TITLE
security: 디버그 로그 레닥션 강화 + 보존 기간 (#27)

### DIFF
--- a/packages/server/src/services/debug.test.ts
+++ b/packages/server/src/services/debug.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { redactSecrets } from './debug.js';
+
+describe('redactSecrets', () => {
+  it('프록시 키(sk-proxy-)를 마스킹', () => {
+    expect(redactSecrets('key=sk-proxy-abc123XYZ')).toContain('sk-proxy-[redacted]');
+    expect(redactSecrets('sk-proxy-abc123XYZ')).not.toContain('abc123XYZ');
+  });
+
+  it('Bearer 토큰을 마스킹', () => {
+    expect(redactSecrets('Authorization: Bearer abc.def-ghi_123')).toContain('Bearer [redacted]');
+  });
+
+  it('x-admin-token / authorization 헤더(JSON)를 마스킹', () => {
+    const json = '{"x-admin-token":"supersecret","authorization":"tok123"}';
+    const out = redactSecrets(json);
+    expect(out).toContain('"x-admin-token":"[redacted]"');
+    expect(out).toContain('"authorization":"[redacted]"');
+    expect(out).not.toContain('supersecret');
+  });
+
+  it('TOKEN/KEY/SECRET= 형식 환경변수를 마스킹', () => {
+    expect(redactSecrets('OPENAI_API_KEY=sk-realvalue123')).toContain('OPENAI_API_KEY=[redacted]');
+    expect(redactSecrets('MY_SECRET=hunter2')).toContain('MY_SECRET=[redacted]');
+  });
+
+  it('서드파티 키 형식(프롬프트 본문에 섞인 백엔드 키)을 마스킹', () => {
+    // OpenAI/Anthropic sk- (20자 이상)
+    expect(redactSecrets('내 키는 sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAA 입니다'))
+      .not.toContain('AAAAAAAAAAAAAAAAAAAAAAAA');
+    // AWS access key id
+    expect(redactSecrets('AKIAIOSFODNN7EXAMPLE')).toContain('AKIA[redacted]');
+    // Google API key (AIza + 35자)
+    expect(redactSecrets('AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe')).toContain('AIza[redacted]');
+    // GitHub token
+    expect(redactSecrets('ghp_0123456789012345678901234567890123456789')).toContain('gh_[redacted]');
+    // xAI key
+    expect(redactSecrets('xai-0123456789abcdefghij')).toContain('xai-[redacted]');
+  });
+
+  it('시크릿이 아닌 평문은 그대로 유지', () => {
+    const plain = '안녕하세요. 오늘 날씨는 어떤가요? skiing is fun.';
+    expect(redactSecrets(plain)).toBe(plain);
+  });
+});

--- a/packages/server/src/services/debug.ts
+++ b/packages/server/src/services/debug.ts
@@ -1,19 +1,29 @@
 import { nanoid } from 'nanoid';
-import { and, desc, eq, like, or, sql } from 'drizzle-orm';
+import { and, desc, eq, like, lt, or, sql } from 'drizzle-orm';
 import { getDatabase } from '../db/client.js';
 import { debugLogs } from '../db/schema.js';
 
 // 디버그 페이로드 최대 크기 (10KB)
 const MAX_FIELD_LENGTH = 10_000;
+// 디버그 로그 보존 기간(일). 민감 데이터(프롬프트/응답)가 무기한 저장되지 않도록 제한.
+const DEBUG_LOG_RETENTION_DAYS = 14;
 const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  // 프록시 자체 키 (구체 패턴 먼저)
   [/\bsk-proxy-[a-zA-Z0-9]+\b/g, 'sk-proxy-[redacted]'],
   [/\bBearer\s+[A-Za-z0-9._\-]+\b/g, 'Bearer [redacted]'],
   [/"x-admin-token"\s*:\s*"[^"]+"/gi, '"x-admin-token":"[redacted]"'],
   [/"authorization"\s*:\s*"[^"]+"/gi, '"authorization":"[redacted]"'],
   [/([A-Z_]*(TOKEN|KEY|SECRET)[A-Z_]*=)[^\s"']+/g, '$1[redacted]'],
+  // 서드파티 키 형식 (프롬프트/응답 본문에 포함될 수 있는 백엔드 키)
+  [/\bsk-[a-zA-Z0-9_-]{20,}\b/g, 'sk-[redacted]'],          // OpenAI/Anthropic (sk-, sk-ant-, sk-proj-)
+  [/\bAKIA[0-9A-Z]{16}\b/g, 'AKIA[redacted]'],               // AWS access key id
+  [/\bAIza[0-9A-Za-z_-]{35}\b/g, 'AIza[redacted]'],          // Google API key
+  [/\bgh[pousr]_[A-Za-z0-9]{36,}\b/g, 'gh_[redacted]'],      // GitHub token
+  [/\bxai-[A-Za-z0-9]{20,}\b/g, 'xai-[redacted]'],           // xAI key
 ];
 
-function redactSecrets(value: string): string {
+// 테스트 가능하도록 export. 디버그 로그 저장 시 시크릿 마스킹에 사용.
+export function redactSecrets(value: string): string {
   let redacted = value;
   for (const [pattern, replacement] of SECRET_PATTERNS) {
     redacted = redacted.replace(pattern, replacement);
@@ -106,10 +116,21 @@ export class DebugService {
         status: 'pending',
         createdAt: new Date().toISOString(),
       });
+      // 보존 기간 초과 로그 정리 (best-effort, 실패해도 요청 흐름에 영향 없음)
+      await this.pruneExpiredLogs();
     } catch (err) {
       console.error('Failed to save debug log start:', err);
     }
     return id;
+  }
+
+  // 보존 기간(DEBUG_LOG_RETENTION_DAYS)을 초과한 디버그 로그 삭제.
+  // 민감 데이터(프롬프트/응답)의 무기한 보관을 방지한다.
+  private async pruneExpiredLogs(): Promise<void> {
+    const cutoff = new Date(Date.now() - DEBUG_LOG_RETENTION_DAYS * 86_400_000).toISOString();
+    const db = getDatabase();
+    // createdAt은 ISO 8601 문자열이라 사전식 비교가 시간순 비교와 일치
+    await db.delete(debugLogs).where(lt(debugLogs.createdAt, cutoff));
   }
 
   // 응답 완료 시 UPDATE


### PR DESCRIPTION
## Summary
- **redactSecrets 패턴 확장**: 서드파티 키 형식(OpenAI/Anthropic `sk-`, AWS `AKIA`, Google `AIza`, GitHub `gh*_`, xAI `xai-`) 추가 — 프롬프트/응답 본문에 섞인 백엔드 키 마스킹
- **보존 기간 도입**: 14일 초과 디버그 로그를 `logStart` 시 best-effort 정리(`pruneExpiredLogs`) — 민감 데이터 무기한 보관 방지

## 비고
- 감사 2-2의 "평문 저장" 지적은 부정확했음(기존 `truncate`가 이미 `redactSecrets` 적용). 본 PR은 패턴 커버리지와 보존 정책을 보강.

## Test plan
- [x] redactSecrets 단위 테스트 6건 추가
- [x] `npx vitest run` → 170 passed / 1 skipped (flip 없음)
- [x] `tsc -b` 통과

Closes #27