### PR TITLE
fix: codex app-server 동시 요청 시 응답 텍스트 교차 오염 (동시성)

### DIFF
--- a/packages/server/src/providers/codex-appserver-executor.concurrency.test.ts
+++ b/packages/server/src/providers/codex-appserver-executor.concurrency.test.ts
@@ -1,0 +1,267 @@
+// codex app-server 동시성 테스트 (#24)
+// 같은 clientKey+model 동시 요청 시 단일 프로세스 공유 + threadId-only 알림 필터로
+// 응답 텍스트가 교차 오염되거나 조기 종료되는 버그를 재현/방지한다.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import type { ExecuteOptions, ProviderEvent } from '@star-cliproxy/shared';
+import type { CodexAppServerProcess } from './codex-appserver-process.js';
+import { CodexAppServerSessionManager } from './codex-appserver-session-manager.js';
+import {
+  executeAppServer,
+  executeStreamAppServer,
+  type AppServerExecutorConfig,
+} from './codex-appserver-executor.js';
+
+const TICK_MS = 5;
+const MODEL = 'gpt-5.3-codex';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function usageBlock() {
+  return {
+    totalTokens: 30,
+    inputTokens: 10,
+    cachedInputTokens: 0,
+    outputTokens: 20,
+    reasoningOutputTokens: 0,
+  };
+}
+
+// 실제 codex app-server의 JSON-RPC stdio 동작을 재현하는 mock:
+// - 알림은 등록된 전체 핸들러에 브로드캐스트 (프로세스 공유와 동일)
+// - turn/start마다 프롬프트 기반 응답을 청크 단위로 비동기 방출
+// - 같은 thread에 turn이 동시에 들어오면 알림이 교차 방출됨 (버그 재현 조건)
+class MockAppServer {
+  private handlers = new Map<string, Set<(params: unknown) => void>>();
+  private threadCounter = 0;
+  private turnCounter = 0;
+  private activeTurnsByThread = new Map<string, number>();
+  private activeTurnsTotal = 0;
+
+  // 동시성 관측 지표
+  maxConcurrentTurnsPerThread = 0;
+  maxConcurrentTurnsTotal = 0;
+
+  isAlive(): boolean {
+    return true;
+  }
+
+  resetRestartCount(): void {}
+
+  sendNotification(): void {}
+
+  onNotification(method: string, handler: (params: unknown) => void): () => void {
+    let set = this.handlers.get(method);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(method, set);
+    }
+    set.add(handler);
+    return () => {
+      set!.delete(handler);
+    };
+  }
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    const p = (params ?? {}) as Record<string, unknown>;
+
+    if (method === 'thread/start') {
+      return { thread: { id: `thread-${++this.threadCounter}` } };
+    }
+    if (method === 'thread/resume') {
+      return { thread: { id: p.threadId } };
+    }
+    if (method === 'turn/start') {
+      const threadId = p.threadId as string;
+      const input = p.input as Array<{ text: string }>;
+      const promptText = input[0]?.text ?? '';
+      // fire-and-forget: 실제 서버처럼 응답 후 알림을 비동기로 방출
+      void this.runTurn(threadId, `turn-${++this.turnCounter}`, promptText);
+      return {};
+    }
+    throw new Error(`예상치 못한 JSON-RPC 메서드: ${method}`);
+  }
+
+  private emit(method: string, params: unknown): void {
+    for (const handler of [...(this.handlers.get(method) ?? [])]) {
+      handler(params);
+    }
+  }
+
+  // 프롬프트에서 결정적으로 응답 생성: "echo(<prompt>)" — turn 할당 순서와 무관하게 검증 가능
+  private async runTurn(threadId: string, turnId: string, promptText: string): Promise<void> {
+    const active = (this.activeTurnsByThread.get(threadId) ?? 0) + 1;
+    this.activeTurnsByThread.set(threadId, active);
+    this.activeTurnsTotal++;
+    this.maxConcurrentTurnsPerThread = Math.max(this.maxConcurrentTurnsPerThread, active);
+    this.maxConcurrentTurnsTotal = Math.max(this.maxConcurrentTurnsTotal, this.activeTurnsTotal);
+
+    const chunks = ['echo(', promptText, ')'];
+    for (const chunk of chunks) {
+      await delay(TICK_MS);
+      this.emit('item/agentMessage/delta', {
+        threadId,
+        turnId,
+        itemId: `item-${turnId}`,
+        delta: chunk,
+      });
+    }
+
+    this.emit('item/completed', {
+      threadId,
+      turnId,
+      item: { type: 'agentMessage', id: `item-${turnId}`, text: chunks.join('') },
+    });
+    this.emit('thread/tokenUsage/updated', {
+      threadId,
+      turnId,
+      tokenUsage: { total: usageBlock(), last: usageBlock() },
+    });
+
+    await delay(TICK_MS);
+    this.activeTurnsByThread.set(threadId, this.activeTurnsByThread.get(threadId)! - 1);
+    this.activeTurnsTotal--;
+    this.emit('turn/completed', {
+      threadId,
+      turn: { id: turnId, status: 'completed', error: null },
+    });
+  }
+}
+
+function createOptions(prompt: string, stream = false): ExecuteOptions {
+  return {
+    messages: [{ role: 'user', content: prompt }],
+    model: MODEL,
+    stream,
+  };
+}
+
+function createConfig(
+  proc: MockAppServer,
+  sessionManager: CodexAppServerSessionManager,
+  clientKey: string,
+): AppServerExecutorConfig {
+  return {
+    model: MODEL,
+    options: {},
+    process: proc as unknown as CodexAppServerProcess,
+    sessionManager,
+    clientKey,
+    timeoutMs: 5000,
+  };
+}
+
+async function collectStreamText(gen: AsyncGenerator<ProviderEvent, void>): Promise<string> {
+  const texts: string[] = [];
+  for await (const event of gen) {
+    if (event.type === 'text_delta') {
+      texts.push(event.text);
+    }
+    if (event.type === 'error') {
+      throw new Error(event.error);
+    }
+  }
+  return texts.join('');
+}
+
+describe('codex app-server 동시성 (#24)', () => {
+  let sessionManager: CodexAppServerSessionManager;
+
+  afterEach(() => {
+    sessionManager?.destroy();
+  });
+
+  it('non-stream: 같은 clientKey+model 동시 요청이 서로의 응답을 오염시키지 않는다', async () => {
+    const proc = new MockAppServer();
+    sessionManager = new CodexAppServerSessionManager();
+    // 같은 스레드를 공유하도록 사전 시드 (세션 재사용 시나리오)
+    sessionManager.set('client-1', 'thread-shared', MODEL);
+
+    const [resultA, resultB] = await Promise.all([
+      executeAppServer(createOptions('prompt-A'), createConfig(proc, sessionManager, 'client-1')),
+      executeAppServer(createOptions('prompt-B'), createConfig(proc, sessionManager, 'client-1')),
+    ]);
+
+    expect(resultA.content).toContain('prompt-A');
+    expect(resultA.content).not.toContain('prompt-B');
+    expect(resultB.content).toContain('prompt-B');
+    expect(resultB.content).not.toContain('prompt-A');
+  });
+
+  it('stream: 같은 clientKey+model 동시 요청의 delta가 교차 유입되지 않는다', async () => {
+    const proc = new MockAppServer();
+    sessionManager = new CodexAppServerSessionManager();
+    sessionManager.set('client-1', 'thread-shared', MODEL);
+
+    const [textA, textB] = await Promise.all([
+      collectStreamText(
+        executeStreamAppServer(
+          createOptions('prompt-A', true),
+          createConfig(proc, sessionManager, 'client-1'),
+        ),
+      ),
+      collectStreamText(
+        executeStreamAppServer(
+          createOptions('prompt-B', true),
+          createConfig(proc, sessionManager, 'client-1'),
+        ),
+      ),
+    ]);
+
+    expect(textA).toContain('prompt-A');
+    expect(textA).not.toContain('prompt-B');
+    expect(textB).toContain('prompt-B');
+    expect(textB).not.toContain('prompt-A');
+  });
+
+  it('같은 thread의 turn은 동시에 1개만 실행된다 (직렬화)', async () => {
+    const proc = new MockAppServer();
+    sessionManager = new CodexAppServerSessionManager();
+    sessionManager.set('client-1', 'thread-shared', MODEL);
+
+    await Promise.all([
+      executeAppServer(createOptions('prompt-A'), createConfig(proc, sessionManager, 'client-1')),
+      executeAppServer(createOptions('prompt-B'), createConfig(proc, sessionManager, 'client-1')),
+      executeAppServer(createOptions('prompt-C'), createConfig(proc, sessionManager, 'client-1')),
+    ]);
+
+    expect(proc.maxConcurrentTurnsPerThread).toBe(1);
+  });
+
+  it('다른 thread의 turn은 여전히 병렬 실행된다 (과잉 직렬화 방지)', async () => {
+    const proc = new MockAppServer();
+    sessionManager = new CodexAppServerSessionManager();
+    // 서로 다른 clientKey → 각자 새 thread 생성 → 병렬 허용
+    const [resultA, resultB] = await Promise.all([
+      executeAppServer(createOptions('prompt-A'), createConfig(proc, sessionManager, 'client-1')),
+      executeAppServer(createOptions('prompt-B'), createConfig(proc, sessionManager, 'client-2')),
+    ]);
+
+    expect(resultA.content).toContain('prompt-A');
+    expect(resultB.content).toContain('prompt-B');
+    expect(proc.maxConcurrentTurnsPerThread).toBe(1);
+    expect(proc.maxConcurrentTurnsTotal).toBeGreaterThanOrEqual(2);
+  });
+
+  it('non-stream + stream 혼합 동시 요청도 직렬화된다', async () => {
+    const proc = new MockAppServer();
+    sessionManager = new CodexAppServerSessionManager();
+    sessionManager.set('client-1', 'thread-shared', MODEL);
+
+    const [resultA, textB] = await Promise.all([
+      executeAppServer(createOptions('prompt-A'), createConfig(proc, sessionManager, 'client-1')),
+      collectStreamText(
+        executeStreamAppServer(
+          createOptions('prompt-B', true),
+          createConfig(proc, sessionManager, 'client-1'),
+        ),
+      ),
+    ]);
+
+    expect(resultA.content).toContain('prompt-A');
+    expect(resultA.content).not.toContain('prompt-B');
+    expect(textB).toContain('prompt-B');
+    expect(textB).not.toContain('prompt-A');
+    expect(proc.maxConcurrentTurnsPerThread).toBe(1);
+  });
+});

--- a/packages/server/src/providers/codex-appserver-executor.ts
+++ b/packages/server/src/providers/codex-appserver-executor.ts
@@ -13,6 +13,22 @@ import type {
 import type { CodexAppServerProcess } from './codex-appserver-process.js';
 import type { CodexAppServerSessionManager } from './codex-appserver-session-manager.js';
 import { convertMessagesToSinglePrompt } from '../utils/message-converter.js';
+import { KeyedMutex } from '../utils/keyed-mutex.js';
+
+// thread당 turn 직렬화 (#24)
+// 단일 프로세스를 공유하므로 같은 thread에 turn이 동시 진행되면
+// threadId 기반 알림 필터가 두 요청을 구분하지 못해 응답이 교차 오염된다.
+// 프로세스 인스턴스별로 뮤텍스를 유지해 같은 threadId의 turn을 FIFO 직렬화한다.
+const turnMutexes = new WeakMap<CodexAppServerProcess, KeyedMutex>();
+
+function getTurnMutex(proc: CodexAppServerProcess): KeyedMutex {
+  let mutex = turnMutexes.get(proc);
+  if (!mutex) {
+    mutex = new KeyedMutex();
+    turnMutexes.set(proc, mutex);
+  }
+  return mutex;
+}
 
 // --- 설정 인터페이스 ---
 
@@ -412,84 +428,90 @@ async function executeTurn(
   const { threadId: rawThreadId, reused } = await getOrCreateThread(proc, existingThreadId, timeoutMs);
   const threadId = requireThreadIdForTurn(rawThreadId, 'getOrCreateThread');
 
-  // 결과 수집용 변수
-  let content = '';
-  let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
-  const deltaChunks: string[] = [];
-
-  // turn/completed 대기용 Promise
-  const turnCompleted = new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error(`turn/completed 타임아웃 (${timeoutMs}ms)`));
-    }, timeoutMs);
-
-    // abort signal 연결
-    if (signal) {
-      signal.addEventListener('abort', () => {
-        clearTimeout(timer);
-        reject(new Error('요청이 취소되었습니다'));
-      }, { once: true });
-    }
-
-    // 알림 핸들러 등록
+  // 같은 thread의 turn 직렬화 (#24): 핸들러 등록~turn 완료까지 락 안에서 수행
+  return getTurnMutex(proc).runExclusive(threadId, async () => {
+    // 결과 수집용 변수
+    let content = '';
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    const deltaChunks: string[] = [];
     const cleanups: (() => void)[] = [];
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
-    // item/agentMessage/delta: 텍스트 청크 수집
-    cleanups.push(proc.onNotification('item/agentMessage/delta', (params) => {
-      const p = params as AgentMessageDeltaParams;
-      if (p.threadId === threadId) {
-        deltaChunks.push(p.delta);
-      }
-    }));
+    try {
+      // turn/completed 대기용 Promise
+      const turnCompleted = new Promise<void>((resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`turn/completed 타임아웃 (${timeoutMs}ms)`));
+        }, timeoutMs);
 
-    // item/completed: agentMessage의 전체 텍스트 추출
-    cleanups.push(proc.onNotification('item/completed', (params) => {
-      const p = params as ItemCompletedParams;
-      if (p.threadId === threadId && p.item.type === 'agentMessage' && p.item.text) {
-        content = p.item.text;
-      }
-    }));
+        // abort signal 연결
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            reject(new Error('요청이 취소되었습니다'));
+          }, { once: true });
+        }
 
-    // thread/tokenUsage/updated: usage 추출
-    cleanups.push(proc.onNotification('thread/tokenUsage/updated', (params) => {
-      const p = params as TokenUsageUpdatedParams;
-      if (p.threadId === threadId) {
-        const last = p.tokenUsage.last;
-        usage = {
-          promptTokens: last.inputTokens,
-          completionTokens: last.outputTokens,
-          totalTokens: last.totalTokens,
-        };
-      }
-    }));
+        // 알림 핸들러 등록
 
-    // turn/completed: 종료 신호
-    cleanups.push(proc.onNotification('turn/completed', (params) => {
-      const p = params as TurnCompletedParams;
-      if (p.threadId === threadId) {
-        clearTimeout(timer);
-        // 핸들러 정리
-        for (const cleanup of cleanups) cleanup();
-        resolve();
+        // item/agentMessage/delta: 텍스트 청크 수집
+        cleanups.push(proc.onNotification('item/agentMessage/delta', (params) => {
+          const p = params as AgentMessageDeltaParams;
+          if (p.threadId === threadId) {
+            deltaChunks.push(p.delta);
+          }
+        }));
+
+        // item/completed: agentMessage의 전체 텍스트 추출
+        cleanups.push(proc.onNotification('item/completed', (params) => {
+          const p = params as ItemCompletedParams;
+          if (p.threadId === threadId && p.item.type === 'agentMessage' && p.item.text) {
+            content = p.item.text;
+          }
+        }));
+
+        // thread/tokenUsage/updated: usage 추출
+        cleanups.push(proc.onNotification('thread/tokenUsage/updated', (params) => {
+          const p = params as TokenUsageUpdatedParams;
+          if (p.threadId === threadId) {
+            const last = p.tokenUsage.last;
+            usage = {
+              promptTokens: last.inputTokens,
+              completionTokens: last.outputTokens,
+              totalTokens: last.totalTokens,
+            };
+          }
+        }));
+
+        // turn/completed: 종료 신호
+        cleanups.push(proc.onNotification('turn/completed', (params) => {
+          const p = params as TurnCompletedParams;
+          if (p.threadId === threadId) {
+            resolve();
+          }
+        }));
+      });
+
+      // turn/start 전송 (v2 스키마: input은 UserInput 배열)
+      await proc.request('turn/start', {
+        threadId,
+        input: buildUserInput(prompt),
+      }, timeoutMs);
+
+      // turn/completed 대기
+      await turnCompleted;
+
+      // content 결정: item/completed의 text 또는 delta 조합
+      if (!content && deltaChunks.length > 0) {
+        content = deltaChunks.join('');
       }
-    }));
+
+      return { threadId, threadReused: reused, content, usage };
+    } finally {
+      // 타임아웃/취소/에러 경로에서도 타이머와 알림 핸들러 누수 방지
+      if (timer) clearTimeout(timer);
+      for (const cleanup of cleanups) cleanup();
+    }
   });
-
-  // turn/start 전송 (v2 스키마: input은 UserInput 배열)
-  await proc.request('turn/start', {
-    threadId,
-    input: buildUserInput(prompt),
-  }, timeoutMs);
-
-  // turn/completed 대기
-  await turnCompleted;
-
-  // content 결정: item/completed의 text 또는 delta 조합
-  if (!content && deltaChunks.length > 0) {
-    content = deltaChunks.join('');
-  }
-
-  return { threadId, threadReused: reused, content, usage };
 }
 
 // --- Streaming 실행 ---
@@ -564,6 +586,9 @@ async function* executeStreamTurn(
   const { threadId: rawThreadId, reused } = await getOrCreateThread(proc, existingThreadId, timeoutMs);
   const threadId = requireThreadIdForTurn(rawThreadId, 'getOrCreateThread');
 
+  // 같은 thread의 turn 직렬화 (#24): 핸들러 등록 전에 락 획득, 모든 종료 경로에서 해제
+  const releaseTurnLock = await getTurnMutex(proc).acquire(threadId);
+
   // 콜백→AsyncGenerator 브릿지 채널
   const channel = new AsyncChannel<ProviderEvent>();
   const cleanups: (() => void)[] = [];
@@ -625,6 +650,7 @@ async function* executeStreamTurn(
   } catch (err) {
     clearTimeout(timer);
     for (const cleanup of cleanups) cleanup();
+    releaseTurnLock();
     throw err;
   }
 
@@ -671,8 +697,9 @@ async function* executeStreamTurn(
       retried: false,
     });
   } finally {
-    // 핸들러 정리
+    // 핸들러 정리 (소비자가 제너레이터를 조기 종료해도 락 해제 보장)
     clearTimeout(timer);
     for (const cleanup of cleanups) cleanup();
+    releaseTurnLock();
   }
 }

--- a/packages/server/src/utils/keyed-mutex.test.ts
+++ b/packages/server/src/utils/keyed-mutex.test.ts
@@ -1,0 +1,78 @@
+// KeyedMutex 단위 테스트
+
+import { describe, it, expect } from 'vitest';
+import { KeyedMutex } from './keyed-mutex.js';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('KeyedMutex', () => {
+  it('같은 키의 작업은 FIFO 순서로 직렬화된다', async () => {
+    const mutex = new KeyedMutex();
+    const order: string[] = [];
+
+    await Promise.all([
+      mutex.runExclusive('k', async () => {
+        order.push('a-start');
+        await delay(10);
+        order.push('a-end');
+      }),
+      mutex.runExclusive('k', async () => {
+        order.push('b-start');
+        await delay(5);
+        order.push('b-end');
+      }),
+      mutex.runExclusive('k', async () => {
+        order.push('c-start');
+        order.push('c-end');
+      }),
+    ]);
+
+    expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end', 'c-start', 'c-end']);
+  });
+
+  it('다른 키의 작업은 병렬 실행된다', async () => {
+    const mutex = new KeyedMutex();
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const task = () =>
+      (async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await delay(10);
+        concurrent--;
+      })();
+
+    await Promise.all([
+      mutex.runExclusive('k1', task),
+      mutex.runExclusive('k2', task),
+    ]);
+
+    expect(maxConcurrent).toBe(2);
+  });
+
+  it('작업이 throw해도 락이 해제되어 다음 작업이 진행된다', async () => {
+    const mutex = new KeyedMutex();
+
+    await expect(
+      mutex.runExclusive('k', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    // 락이 해제되었으면 다음 작업이 즉시 실행 가능
+    const result = await mutex.runExclusive('k', async () => 'ok');
+    expect(result).toBe('ok');
+  });
+
+  it('acquire의 해제 함수는 멱등이다', async () => {
+    const mutex = new KeyedMutex();
+
+    const release = await mutex.acquire('k');
+    release();
+    release(); // 중복 호출해도 부작용 없음
+
+    const result = await mutex.runExclusive('k', async () => 'ok');
+    expect(result).toBe('ok');
+  });
+});

--- a/packages/server/src/utils/keyed-mutex.ts
+++ b/packages/server/src/utils/keyed-mutex.ts
@@ -1,0 +1,44 @@
+// 키 단위 비동기 뮤텍스
+// 같은 키의 작업은 FIFO 직렬화, 다른 키는 병렬 허용.
+// codex app-server thread당 turn 직렬화(#24)에 사용.
+
+export class KeyedMutex {
+  // 키별 대기 체인의 꼬리. 새 작업은 이전 꼬리가 해소된 뒤 진입한다.
+  private tails = new Map<string, Promise<void>>();
+
+  // 락 획득. 반환된 함수를 호출하면 해제된다 (멱등).
+  // 호출 측은 반드시 try/finally로 해제를 보장할 것.
+  async acquire(key: string): Promise<() => void> {
+    const prev = this.tails.get(key) ?? Promise.resolve();
+
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const tail = prev.then(() => gate);
+    this.tails.set(key, tail);
+
+    await prev;
+
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      releaseGate();
+      // 내 뒤에 대기자가 없으면 맵에서 제거 (메모리 누수 방지)
+      if (this.tails.get(key) === tail) {
+        this.tails.delete(key);
+      }
+    };
+  }
+
+  // 락을 잡고 fn 실행 후 자동 해제
+  async runExclusive<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const release = await this.acquire(key);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- 같은 clientKey+model 동시 요청이 단일 공유 `CodexAppServerProcess`에서 같은 thread를 resume하면, threadId-only 알림 필터가 두 turn을 구분하지 못해 응답 텍스트가 교차 오염되고 첫 turn/completed에 둘 다 조기 종료되던 버그 수정
- `KeyedMutex`(키별 FIFO async mutex) 도입 → (process, threadId) 단위로 turn 실행을 직렬화 (non-stream + stream 모두). 다른 thread는 기존대로 병렬 실행
- 알림 핸들러 등록을 락 내부로 이동하고, 모든 종료 경로(타임아웃/abort/turn-start 실패/제너레이터 조기 종료)에서 try/finally로 락 해제 + 핸들러/타이머 정리 보장 (non-stream 경로의 기존 핸들러 누수도 함께 해소)
- mock app-server 동시성 테스트 하네스 신규 구축 (기존 app-server 테스트 전무)

## Test plan
- [x] RED 재현: 수정 전 신규 테스트 5건 중 4건 실패 — 교차 오염(`resultA.content === 'echo(prompt-B)'`), 같은 thread 동시 turn 3개 관측
- [x] GREEN: 수정 후 동시성 테스트 5건 + KeyedMutex 단위 테스트 4건 통과
- [x] 과잉 직렬화 방지 검증: 다른 thread turn은 병렬 유지 (`maxConcurrentTurnsTotal >= 2`)
- [x] flip 점검: `npm run build` 성공 + `npm test` **179 passed / 1 skipped** (기준선 170 → 신규 9건, 기존 통과 회귀 0건)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)