### PR TITLE
config: loader 무검증 'as' 캐스팅을 Zod 스키마 검증으로 교체

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5848,7 +5848,8 @@
         "fastify": "^5.8.5",
         "nanoid": "^5.1.5",
         "p-queue": "^8.1.0",
-        "yaml": "^2.8.3"
+        "yaml": "^2.8.3",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.15.0",
@@ -6040,6 +6041,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/server/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/shared": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,8 @@
     "fastify": "^5.8.5",
     "nanoid": "^5.1.5",
     "p-queue": "^8.1.0",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.15.0",

--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -1,0 +1,254 @@
+// config loader Zod 검증 테스트 (#30)
+// 기존 동작 보존(기본값 폴백, env 치환, null 허용) + 신규 fail-fast 검증
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  DEFAULT_SERVER_PORT,
+  DEFAULT_DASHBOARD_PORT,
+  DEFAULT_MAX_CONCURRENT,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_RATE_LIMIT_RPM,
+} from '@star-cliproxy/shared';
+import { loadConfig } from './loader.js';
+
+let tempDir: string;
+
+function writeConfig(yaml: string): string {
+  const path = join(tempDir, 'config.yaml');
+  writeFileSync(path, yaml, 'utf-8');
+  return path;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'cliproxy-config-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('loadConfig — 기존 동작 보존', () => {
+  it('config 파일이 없으면 전체 기본값을 반환한다', () => {
+    const config = loadConfig(join(tempDir, 'nonexistent.yaml'));
+
+    expect(config.server.port).toBe(DEFAULT_SERVER_PORT);
+    expect(config.dashboard.port).toBe(DEFAULT_DASHBOARD_PORT);
+    expect(config.providers.claude.cli_path).toBe('claude');
+    expect(config.providers.claude.max_concurrent).toBe(DEFAULT_MAX_CONCURRENT);
+    expect(config.rateLimits.global.rpm).toBe(DEFAULT_RATE_LIMIT_RPM);
+    expect(config.modelMappings.length).toBeGreaterThan(0);
+  });
+
+  it('유효한 config 값이 그대로 반영된다', () => {
+    const path = writeConfig(`
+server:
+  port: 9999
+  host: "0.0.0.0"
+providers:
+  claude:
+    enabled: false
+    cli_path: "/usr/local/bin/claude"
+    timeout_ms: 60000
+model_mappings:
+  - alias: "my-model"
+    provider: "claude"
+    actual_model: "claude-sonnet-4-6"
+`);
+    const config = loadConfig(path);
+
+    expect(config.server.port).toBe(9999);
+    expect(config.server.host).toBe('0.0.0.0');
+    expect(config.providers.claude.enabled).toBe(false);
+    expect(config.providers.claude.cli_path).toBe('/usr/local/bin/claude');
+    expect(config.providers.claude.timeout_ms).toBe(60000);
+    // 미지정 필드는 기본값 유지
+    expect(config.providers.claude.max_concurrent).toBe(DEFAULT_MAX_CONCURRENT);
+    expect(config.providers.codex.timeout_ms).toBe(DEFAULT_TIMEOUT_MS);
+    expect(config.modelMappings).toEqual([
+      {
+        alias: 'my-model',
+        provider: 'claude',
+        actual_model: 'claude-sonnet-4-6',
+        reasoning_effort: undefined,
+        provider_overrides: undefined,
+      },
+    ]);
+  });
+
+  it('null 값(빈 env var 치환 등)은 기본값으로 폴백한다', () => {
+    // YAML에서 "port:" 처럼 값이 비면 null — 기존 ?? 폴백 동작 유지
+    const path = writeConfig(`
+server:
+  port:
+  host:
+cache:
+  enabled:
+`);
+    const config = loadConfig(path);
+
+    expect(config.server.port).toBe(DEFAULT_SERVER_PORT);
+    expect(config.server.host).toBe('127.0.0.1');
+    expect(config.cache.enabled).toBe(true);
+  });
+
+  it('환경변수 치환(${VAR})이 동작한다', () => {
+    process.env.TEST_CLIPROXY_TOKEN = 'secret-token-123';
+    try {
+      const path = writeConfig(`
+auth:
+  admin_token: "\${TEST_CLIPROXY_TOKEN}"
+`);
+      const config = loadConfig(path);
+      expect(config.auth.adminToken).toBe('secret-token-123');
+    } finally {
+      delete process.env.TEST_CLIPROXY_TOKEN;
+    }
+  });
+
+  it('알 수 없는 키는 무시한다 (전방 호환)', () => {
+    const path = writeConfig(`
+server:
+  port: 9999
+  future_option: true
+totally_new_section:
+  foo: bar
+`);
+    const config = loadConfig(path);
+    expect(config.server.port).toBe(9999);
+  });
+
+  it('커스텀 프로바이더가 빌트인과 함께 병합된다', () => {
+    const path = writeConfig(`
+providers:
+  my-ollama:
+    enabled: true
+    cli_path: "ollama"
+    default_model: "llama3"
+`);
+    const config = loadConfig(path);
+
+    expect(config.providers['my-ollama'].cli_path).toBe('ollama');
+    expect(config.providers['my-ollama'].default_model).toBe('llama3');
+    expect(config.providers.claude).toBeDefined();
+    expect(config.rateLimits.perProvider['my-ollama']).toEqual({ rpm: 20 });
+  });
+
+  it('reasoning_effort 미지원 값은 조용히 무시한다 (기존 동작)', () => {
+    const path = writeConfig(`
+model_mappings:
+  - alias: "m1"
+    provider: "claude"
+    actual_model: "x"
+    reasoning_effort: "ultra-mega"
+`);
+    const config = loadConfig(path);
+    expect(config.modelMappings[0].reasoning_effort).toBeUndefined();
+  });
+
+  it('provider_overrides 비화이트리스트 키는 조용히 드롭한다 (기존 동작)', () => {
+    const path = writeConfig(`
+model_mappings:
+  - alias: "m1"
+    provider: "codex"
+    actual_model: "x"
+    provider_overrides:
+      timeout_ms: 5000
+      cli_path: "/evil/path"
+      mode: "sdk"
+`);
+    const config = loadConfig(path);
+    expect(config.modelMappings[0].provider_overrides).toEqual({ timeout_ms: 5000 });
+  });
+});
+
+describe('loadConfig — Zod fail-fast 검증 (#30)', () => {
+  it('server.port가 숫자가 아니면 경로를 포함한 에러를 던진다', () => {
+    const path = writeConfig(`
+server:
+  port: "abc"
+`);
+    expect(() => loadConfig(path)).toThrow(/server\.port/);
+  });
+
+  it('server.port가 유효 범위(1-65535)를 벗어나면 에러를 던진다', () => {
+    const path = writeConfig(`
+server:
+  port: 70000
+`);
+    expect(() => loadConfig(path)).toThrow(/server\.port/);
+  });
+
+  it('provider timeout_ms가 음수이면 에러를 던진다', () => {
+    const path = writeConfig(`
+providers:
+  claude:
+    timeout_ms: -1
+`);
+    expect(() => loadConfig(path)).toThrow(/providers\.claude\.timeout_ms/);
+  });
+
+  it('cache.enabled가 불리언이 아니면 에러를 던진다', () => {
+    const path = writeConfig(`
+cache:
+  enabled: "yes please"
+`);
+    expect(() => loadConfig(path)).toThrow(/cache\.enabled/);
+  });
+
+  it('model_mappings에 alias가 없으면 에러를 던진다', () => {
+    const path = writeConfig(`
+model_mappings:
+  - provider: "claude"
+    actual_model: "claude-sonnet-4-6"
+`);
+    expect(() => loadConfig(path)).toThrow(/model_mappings/);
+  });
+
+  it('model_mappings에 provider가 없으면 에러를 던진다', () => {
+    const path = writeConfig(`
+model_mappings:
+  - alias: "my-model"
+    actual_model: "claude-sonnet-4-6"
+`);
+    expect(() => loadConfig(path)).toThrow(/model_mappings/);
+  });
+
+  it('extra_args에 문자열이 아닌 항목이 있으면 에러를 던진다', () => {
+    const path = writeConfig(`
+providers:
+  claude:
+    extra_args:
+      - "--flag"
+      - 123
+`);
+    expect(() => loadConfig(path)).toThrow(/extra_args/);
+  });
+
+  it('mode가 허용 값이 아니면 에러를 던진다', () => {
+    const path = writeConfig(`
+providers:
+  codex:
+    mode: "turbo"
+`);
+    expect(() => loadConfig(path)).toThrow(/mode/);
+  });
+
+  it('에러 메시지에 config 파일 경로가 포함된다', () => {
+    const path = writeConfig(`
+server:
+  port: "abc"
+`);
+    expect(() => loadConfig(path)).toThrow(new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+});
+
+describe('loadConfig — 실제 예제 config 회귀', () => {
+  it('저장소의 config.example.yaml이 검증을 통과한다', () => {
+    // 프로젝트 루트의 예제 config — 스키마가 실제 사용 형태와 어긋나지 않는지 보증
+    const examplePath = join(import.meta.dirname, '../../../../config.example.yaml');
+    expect(() => loadConfig(examplePath)).not.toThrow();
+  });
+});

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -1,7 +1,9 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { parse as parseYaml } from 'yaml';
+import { z } from 'zod';
 import type { AppConfig, ProviderConfigYaml, PluginEntry, ProviderOverrides, ReasoningEffort } from '@star-cliproxy/shared';
+import { rawConfigSchema, type RawProviderConfig } from './schema.js';
 import {
   DEFAULT_SERVER_PORT,
   DEFAULT_DASHBOARD_PORT,
@@ -89,7 +91,7 @@ const BUILTIN_DEFAULTS: Record<string, { cliPath: string; defaultModel: string }
 export function loadConfig(configPath?: string): AppConfig {
   const resolvedPath = configPath ?? resolve(process.cwd(), 'config.yaml');
 
-  let rawConfig: Record<string, unknown> = {};
+  let rawConfig: unknown = {};
 
   if (existsSync(resolvedPath)) {
     const content = readFileSync(resolvedPath, 'utf-8');
@@ -97,22 +99,31 @@ export function loadConfig(configPath?: string): AppConfig {
     rawConfig = parseYaml(substituted) ?? {};
   }
 
-  const server = rawConfig.server as Record<string, unknown> | undefined;
-  const dashboard = rawConfig.dashboard as Record<string, unknown> | undefined;
-  const database = rawConfig.database as Record<string, unknown> | undefined;
-  const auth = rawConfig.auth as Record<string, unknown> | undefined;
-  const providers = rawConfig.providers as Record<string, Record<string, unknown>> | undefined;
-  const rateLimits = rawConfig.rate_limits as Record<string, unknown> | undefined;
-  const cache = rawConfig.cache as Record<string, unknown> | undefined;
-  const validation = rawConfig.validation as Record<string, unknown> | undefined;
-  const modelMappings = rawConfig.model_mappings as Array<Record<string, string | undefined>> | undefined;
-  const rawPlugins = rawConfig.plugins as Array<Record<string, unknown>> | undefined;
+  // Zod 스키마 검증 (#30): 잘못된 타입/범위는 기동 시점에 경로 포함 에러로 거부
+  const parsed = rawConfigSchema.safeParse(rawConfig);
+  if (!parsed.success) {
+    throw new Error(
+      `config 검증 실패 (${resolvedPath}):\n${z.prettifyError(parsed.error)}`,
+    );
+  }
 
-  const corsObj = server?.cors as Record<string, unknown> | undefined;
-  const globalLimits = rateLimits?.global as Record<string, number> | undefined;
-  const perProvider = rateLimits?.per_provider as Record<string, Record<string, number>> | undefined;
+  const {
+    server,
+    dashboard,
+    database,
+    auth,
+    providers,
+    rate_limits: rateLimits,
+    cache,
+    validation,
+    model_mappings: modelMappings,
+    plugins: rawPlugins,
+  } = parsed.data;
 
-  const initialKeys = (auth?.initial_keys as Array<Record<string, string>> | undefined) ?? [];
+  const globalLimits = rateLimits?.global;
+  const perProvider = rateLimits?.per_provider;
+
+  const initialKeys = auth?.initial_keys ?? [];
 
   // 빌트인 프로바이더 설정 병합
   const providerConfigs: Record<string, ProviderConfigYaml> = {};
@@ -138,29 +149,29 @@ export function loadConfig(configPath?: string): AppConfig {
 
   // 플러그인 엔트리 파싱
   const plugins: PluginEntry[] = (rawPlugins ?? []).map((p) => ({
-    path: (p.path as string) ?? '',
+    path: p.path,
     config: p.config as Partial<ProviderConfigYaml> | undefined,
   }));
 
   return {
     server: {
-      port: (server?.port as number) ?? DEFAULT_SERVER_PORT,
-      host: (server?.host as string) ?? DEFAULT_HOST,
+      port: server?.port ?? DEFAULT_SERVER_PORT,
+      host: server?.host ?? DEFAULT_HOST,
       cors: {
-        origins: (corsObj?.origins as string[]) ?? [`http://localhost:${DEFAULT_DASHBOARD_PORT}`],
+        origins: server?.cors?.origins ?? [`http://localhost:${DEFAULT_DASHBOARD_PORT}`],
       },
     },
     dashboard: {
-      port: (dashboard?.port as number) ?? DEFAULT_DASHBOARD_PORT,
-      host: (dashboard?.host as string) ?? DEFAULT_HOST,
+      port: dashboard?.port ?? DEFAULT_DASHBOARD_PORT,
+      host: dashboard?.host ?? DEFAULT_HOST,
     },
     database: {
       // DB 경로를 config.yaml이 있는 디렉토리 기준으로 해석
-      path: resolve(dirname(resolvedPath), (database?.path as string) ?? './data/cliproxy.db'),
+      path: resolve(dirname(resolvedPath), database?.path ?? './data/cliproxy.db'),
     },
     auth: {
-      enabled: (auth?.enabled as boolean) ?? true,
-      adminToken: (auth?.admin_token as string) ?? process.env.ADMIN_TOKEN ?? '',
+      enabled: auth?.enabled ?? true,
+      adminToken: auth?.admin_token ?? process.env.ADMIN_TOKEN ?? '',
       initialKeys: initialKeys.map((k) => ({
         name: k.name ?? 'default',
         key: k.key ?? process.env.PROXY_API_KEY ?? '',
@@ -176,21 +187,21 @@ export function loadConfig(configPath?: string): AppConfig {
       perProvider: perProviderConfig,
     },
     cache: {
-      enabled: (cache?.enabled as boolean) ?? true,
-      ttlSeconds: (cache?.ttl_seconds as number) ?? DEFAULT_CACHE_TTL_SECONDS,
-      maxEntries: (cache?.max_entries as number) ?? DEFAULT_CACHE_MAX_ENTRIES,
+      enabled: cache?.enabled ?? true,
+      ttlSeconds: cache?.ttl_seconds ?? DEFAULT_CACHE_TTL_SECONDS,
+      maxEntries: cache?.max_entries ?? DEFAULT_CACHE_MAX_ENTRIES,
     },
     validation: {
-      maxMessageCount: (validation?.max_message_count as number) ?? DEFAULT_MAX_MESSAGE_COUNT,
-      maxMessageLength: (validation?.max_message_length as number) ?? DEFAULT_MAX_MESSAGE_LENGTH,
-      maxPromptLength: (validation?.max_prompt_length as number) ?? DEFAULT_MAX_PROMPT_LENGTH,
-      maxResponseLength: (validation?.max_response_length as number) ?? DEFAULT_MAX_RESPONSE_LENGTH,
-      bodyLimitBytes: (validation?.body_limit_bytes as number) ?? DEFAULT_BODY_LIMIT_BYTES,
+      maxMessageCount: validation?.max_message_count ?? DEFAULT_MAX_MESSAGE_COUNT,
+      maxMessageLength: validation?.max_message_length ?? DEFAULT_MAX_MESSAGE_LENGTH,
+      maxPromptLength: validation?.max_prompt_length ?? DEFAULT_MAX_PROMPT_LENGTH,
+      maxResponseLength: validation?.max_response_length ?? DEFAULT_MAX_RESPONSE_LENGTH,
+      bodyLimitBytes: validation?.body_limit_bytes ?? DEFAULT_BODY_LIMIT_BYTES,
     },
     modelMappings: modelMappings?.map((m) => ({
-      alias: m.alias as string,
-      provider: m.provider as string,
-      actual_model: (m.actual_model as string | undefined) ?? '',
+      alias: m.alias,
+      provider: m.provider,
+      actual_model: m.actual_model ?? '',
       reasoning_effort: normalizeReasoningEffort(m.reasoning_effort),
       provider_overrides: normalizeProviderOverrides(m.provider_overrides),
     })) ?? [
@@ -212,57 +223,29 @@ export function loadConfig(configPath?: string): AppConfig {
 }
 
 function mergeProviderConfig(
-  raw: Record<string, unknown> | undefined,
+  raw: RawProviderConfig | undefined,
   cliPath: string,
   defaultModel: string,
 ): ProviderConfigYaml {
   const defaults = defaultProviderConfig(cliPath, defaultModel);
   if (!raw) return defaults;
 
-  // SDK 옵션 파싱
-  const rawSdkOptions = raw.sdk_options as Record<string, unknown> | undefined;
-  const sdkOptions = rawSdkOptions ? {
-    max_turns: rawSdkOptions.max_turns as number | undefined,
-    permission_mode: rawSdkOptions.permission_mode as string | undefined,
-    allowed_tools: rawSdkOptions.allowed_tools as string[] | undefined,
-    disallowed_tools: rawSdkOptions.disallowed_tools as string[] | undefined,
-    max_budget_usd: rawSdkOptions.max_budget_usd as number | undefined,
-    session_ttl_ms: rawSdkOptions.session_ttl_ms as number | undefined,
-    enable_session_reuse: rawSdkOptions.enable_session_reuse as boolean | undefined,
-    persist_session: rawSdkOptions.persist_session as boolean | undefined,
-  } : undefined;
-
-  // App Server 옵션 파싱 (Codex app-server 모드)
-  const rawAppServerOptions = raw.app_server_options as Record<string, unknown> | undefined;
-  const appServerOptions = rawAppServerOptions ? {
-    transport: (rawAppServerOptions.transport as 'stdio' | 'websocket') ?? 'stdio',
-    websocket_url: rawAppServerOptions.websocket_url as string | undefined,
-    session_ttl_ms: rawAppServerOptions.session_ttl_ms as number | undefined,
-    enable_session_reuse: rawAppServerOptions.enable_session_reuse as boolean | undefined,
-    max_turns: rawAppServerOptions.max_turns as number | undefined,
-    auto_restart: rawAppServerOptions.auto_restart as boolean | undefined,
-    max_restart_count: rawAppServerOptions.max_restart_count as number | undefined,
-  } : undefined;
-
-  // CLI 옵션 파싱 (Codex CLI 모드)
-  const rawCliOptions = raw.cli_options as Record<string, unknown> | undefined;
-  const cliOptions = rawCliOptions ? {
-    ephemeral: rawCliOptions.ephemeral as boolean | undefined,
-    enable_session_reuse: rawCliOptions.enable_session_reuse as boolean | undefined,
-    session_ttl_ms: rawCliOptions.session_ttl_ms as number | undefined,
-  } : undefined;
+  // App Server 옵션: transport만 기본값 주입 (나머지는 스키마 검증된 값 그대로)
+  const appServerOptions = raw.app_server_options
+    ? { ...raw.app_server_options, transport: raw.app_server_options.transport ?? 'stdio' as const }
+    : undefined;
 
   return {
-    enabled: (raw.enabled as boolean) ?? defaults.enabled,
-    cli_path: (raw.cli_path as string) ?? defaults.cli_path,
-    default_model: (raw.default_model as string) ?? defaults.default_model,
-    max_concurrent: (raw.max_concurrent as number) ?? defaults.max_concurrent,
-    timeout_ms: (raw.timeout_ms as number) ?? defaults.timeout_ms,
-    extra_args: (raw.extra_args as string[]) ?? defaults.extra_args,
-    working_dir: (raw.working_dir as string) ?? undefined,
-    mode: (raw.mode as 'cli' | 'sdk' | 'app-server') ?? undefined,
-    sdk_options: sdkOptions,
+    enabled: raw.enabled ?? defaults.enabled,
+    cli_path: raw.cli_path ?? defaults.cli_path,
+    default_model: raw.default_model ?? defaults.default_model,
+    max_concurrent: raw.max_concurrent ?? defaults.max_concurrent,
+    timeout_ms: raw.timeout_ms ?? defaults.timeout_ms,
+    extra_args: raw.extra_args ?? defaults.extra_args,
+    working_dir: raw.working_dir ?? undefined,
+    mode: raw.mode ?? undefined,
+    sdk_options: raw.sdk_options,
     app_server_options: appServerOptions,
-    cli_options: cliOptions,
+    cli_options: raw.cli_options,
   };
 }

--- a/packages/server/src/config/schema.ts
+++ b/packages/server/src/config/schema.ts
@@ -1,0 +1,147 @@
+// config.yaml raw 구조 Zod 스키마 (#30)
+// YAML 파싱 직후의 snake_case 구조를 검증한다. 기본값 주입은 loader.ts가 담당.
+//
+// 설계 결정:
+// - 모든 필드는 선택적(opt) — 누락 시 loader가 기본값 폴백 (기존 동작 유지)
+// - null은 undefined와 동일 취급 — 빈 env var 치환(`port: ${PORT}` → `port:`)이 null이 되는 경우
+// - 알 수 없는 키는 무시 (zod 기본 strip) — 전방 호환
+// - model_mappings의 alias/provider만 필수 — 누락 시 런타임 오동작 대신 기동 거부
+// - reasoning_effort / provider_overrides 값 정규화는 기존 normalize 함수가 담당 (silently-ignore 유지)
+
+import { z } from 'zod';
+
+// null → undefined 변환 포함 선택적 필드
+const opt = <T extends z.ZodType>(schema: T) =>
+  schema.nullish().transform((v) => v ?? undefined);
+
+const port = z.int().min(1).max(65535);
+const positiveInt = z.int().positive();
+const positiveNumber = z.number().positive();
+
+const serverSchema = z.object({
+  port: opt(port),
+  host: opt(z.string()),
+  cors: opt(
+    z.object({
+      origins: opt(z.array(z.string())),
+    }),
+  ),
+});
+
+const dashboardSchema = z.object({
+  port: opt(port),
+  host: opt(z.string()),
+});
+
+const databaseSchema = z.object({
+  path: opt(z.string()),
+});
+
+const authSchema = z.object({
+  enabled: opt(z.boolean()),
+  admin_token: opt(z.string()),
+  initial_keys: opt(
+    z.array(
+      z.object({
+        name: opt(z.string()),
+        key: opt(z.string()),
+      }),
+    ),
+  ),
+});
+
+const sdkOptionsSchema = z.object({
+  max_turns: opt(positiveInt),
+  permission_mode: opt(z.string()),
+  allowed_tools: opt(z.array(z.string())),
+  disallowed_tools: opt(z.array(z.string())),
+  max_budget_usd: opt(positiveNumber),
+  session_ttl_ms: opt(positiveInt),
+  enable_session_reuse: opt(z.boolean()),
+  persist_session: opt(z.boolean()),
+});
+
+const appServerOptionsSchema = z.object({
+  transport: opt(z.enum(['stdio', 'websocket'])),
+  websocket_url: opt(z.string()),
+  session_ttl_ms: opt(positiveInt),
+  enable_session_reuse: opt(z.boolean()),
+  max_turns: opt(positiveInt),
+  auto_restart: opt(z.boolean()),
+  max_restart_count: opt(positiveInt),
+});
+
+const cliOptionsSchema = z.object({
+  ephemeral: opt(z.boolean()),
+  enable_session_reuse: opt(z.boolean()),
+  session_ttl_ms: opt(positiveInt),
+});
+
+const providerSchema = z.object({
+  enabled: opt(z.boolean()),
+  cli_path: opt(z.string()),
+  default_model: opt(z.string()),
+  max_concurrent: opt(positiveInt),
+  timeout_ms: opt(positiveInt),
+  extra_args: opt(z.array(z.string())),
+  working_dir: opt(z.string()),
+  mode: opt(z.enum(['cli', 'sdk', 'app-server'])),
+  sdk_options: opt(sdkOptionsSchema),
+  app_server_options: opt(appServerOptionsSchema),
+  cli_options: opt(cliOptionsSchema),
+});
+
+const rateLimitsSchema = z.object({
+  global: opt(
+    z.object({
+      rpm: opt(positiveInt),
+      rpd: opt(positiveInt),
+    }),
+  ),
+  per_provider: opt(z.record(z.string(), opt(z.object({ rpm: opt(positiveInt) })))),
+});
+
+const cacheSchema = z.object({
+  enabled: opt(z.boolean()),
+  ttl_seconds: opt(positiveInt),
+  max_entries: opt(positiveInt),
+});
+
+const validationSchema = z.object({
+  max_message_count: opt(positiveInt),
+  max_message_length: opt(positiveInt),
+  max_prompt_length: opt(positiveInt),
+  max_response_length: opt(positiveInt),
+  body_limit_bytes: opt(positiveInt),
+});
+
+const modelMappingSchema = z.object({
+  alias: z.string().min(1),
+  provider: z.string().min(1),
+  actual_model: opt(z.string()),
+  // 값 화이트리스트 검증은 normalizeReasoningEffort가 수행 (미지원 값 silently 무시)
+  reasoning_effort: opt(z.string()),
+  // 키 화이트리스트 정규화는 normalizeProviderOverrides가 수행 (비허용 키 silently 드롭)
+  provider_overrides: z.unknown().optional(),
+});
+
+const pluginSchema = z.object({
+  path: z.string().min(1),
+  config: opt(providerSchema),
+});
+
+export const rawConfigSchema = z.object({
+  server: opt(serverSchema),
+  dashboard: opt(dashboardSchema),
+  database: opt(databaseSchema),
+  auth: opt(authSchema),
+  providers: opt(z.record(z.string(), opt(providerSchema))),
+  plugins: opt(z.array(pluginSchema)),
+  rate_limits: opt(rateLimitsSchema),
+  cache: opt(cacheSchema),
+  validation: opt(validationSchema),
+  model_mappings: opt(z.array(modelMappingSchema)),
+});
+
+export type RawConfig = z.infer<typeof rawConfigSchema>;
+export type RawProviderConfig = z.infer<typeof providerSchema>;


### PR DESCRIPTION
## Summary
- `config/loader.ts`의 무검증 `as` 캐스팅 전부 제거 → zod@4.4.3 기반 `config/schema.ts`로 기동 시 fail-fast 검증. 잘못된 타입/범위는 경로 포함 에러(`z.prettifyError`)로 기동 거부
- 기존 동작 보존: 기본값 폴백, null=undefined 취급(빈 env var 치환), unknown key 무시(전방 호환), reasoning_effort/provider_overrides의 silently-ignore 정규화
- 강화: `model_mappings[].alias/provider` 필수, plugin path 필수, port 범위(1-65535), 양수 검증(*_ms, max_*, rpm), mode/transport enum

## Test plan
- [x] RED 선행: fail-fast 테스트 9건이 기존 코드에서 실패 확인 → 구현 후 GREEN
- [x] 기존 동작 보존 테스트 9건 + 저장소 `config.example.yaml` 회귀 테스트 통과
- [x] flip 점검: `npm run build` 성공 + `npm test` **197 passed / 1 skipped** (기준선 179 → +18, 기존 통과 회귀 0건)
- [x] `npm audit --omit=dev --audit-level=high` 0건 (zod 의존성 0개)
- [x] E2E: 실제 `config.yaml` 검증 통과(프로바이더 6종/매핑 22건) + 임시 config 부팅 후 `/health` 200 + 잘못된 config(`port: "abc"`, `timeout_ms: -5`)는 경로 포함 에러로 기동 거부 확인

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)