### PR TITLE
chore: add .gitattributes to pin LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# 모든 텍스트 파일을 저장소에서 LF로 정규화 (core.autocrlf 설정과 무관하게 일관성 보장)
+* text=auto eol=lf
+
+# 셸 스크립트는 반드시 LF
+*.sh text eol=lf
+
+# Windows 배치 스크립트는 CRLF (해당 파일이 있을 경우)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# 바이너리 — 정규화/diff 제외
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.eot binary
+*.db binary
+*.sqlite binary
+*.node binary


### PR DESCRIPTION
## Summary
`core.autocrlf=true` caused `LF will be replaced by CRLF` warnings on every git operation. This pins all text files to LF via `.gitattributes` (shell scripts always LF, Windows batch CRLF, binaries excluded).

The repository already stores content as LF, so `git add --renormalize .` changed **0 files** — this only fixes checkout normalization and silences the warnings.

## Test plan
- [x] `git add --renormalize .` → no content changes (repo already LF)
- [x] `.gitattributes` covers source, configs, shell scripts, and excludes binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)