### PR TITLE
Vision guide + deprecate Gemini CLI (Closes #36)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@ client.chat.completions.create(
 ## 왜 star-cliproxy인가요?
 
 - 💸 **API 키가 아닌 구독 활용** — 토큰 종량 과금 대신 Claude Max / ChatGPT Pro 등 구독으로 처리됩니다.
-- 🔌 **하나의 엔드포인트, 여러 백엔드** — 빌트인 CLI 6종(Claude, Codex, Copilot, Gemini, Antigravity, Grok) **+** OpenAI 호환 HTTP 서버(vLLM, Ollama, MLX, LM Studio) **+** 커스텀 플러그인.
+- 🔌 **하나의 엔드포인트, 여러 백엔드** — 빌트인 CLI 5종(Claude, Codex, Copilot, Antigravity, Grok) **+** OpenAI 호환 HTTP 서버(vLLM, Ollama, MLX, LM Studio) **+** 커스텀 플러그인.
 - 🧭 **스마트 라우팅** — 별칭 기반 모델 매핑, 우선순위 폴백 체인, 모델 단위 provider 오버라이드, 세션 재사용(`codex exec resume`).
 - ⚙️ **다양한 실행 모드** — `cli`, Claude **Agent SDK**, Codex **app-server**, 그리고 신규 **channel-worker** bridge 모드.
 - 📡 **진짜 SSE 스트리밍** — NDJSON/JSONL 이벤트 파이프 그대로 전달 (사후 청크 분할이 아님).
@@ -69,7 +69,7 @@ npm run dev:dashboard  # 대시보드   → http://localhost:5300
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Claude Pro / Max | `npm i -g @anthropic-ai/claude-code` |
 | [Codex](https://github.com/openai/codex) | ChatGPT Plus / Pro | `npm i -g @openai/codex` |
 | [Copilot CLI](https://docs.github.com/en/copilot) | GitHub Copilot | `gh extension install github/gh-copilot` |
-| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google AI Studio | `npm i -g @google/gemini-cli` |
+| ~~Gemini CLI~~ *(단종)* | — | 아래 **Antigravity CLI** 사용 — Gemini CLI는 Google이 단종 |
 | [Antigravity CLI](https://antigravity.google/) | Google AI Pro / Ultra | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` |
 | [Grok Build CLI](https://x.ai/cli) | SuperGrok / X Premium+ | `curl -fsSL https://x.ai/cli/install.sh \| bash` |
 | **HTTP** | OpenAI 호환 서버 | 대시보드에서 추가 (vLLM, Ollama, MLX, LM Studio…) |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ client.chat.completions.create(
 ## Why star-cliproxy?
 
 - 💸 **Subscriptions, not API keys** — bill against Claude Max / ChatGPT Pro / etc. instead of metered API tokens.
-- 🔌 **One endpoint, many backends** — 6 built-in CLIs (Claude, Codex, Copilot, Gemini, Antigravity, Grok) **+** any OpenAI-compatible HTTP server (vLLM, Ollama, MLX, LM Studio) **+** custom plugins.
+- 🔌 **One endpoint, many backends** — 5 built-in CLIs (Claude, Codex, Copilot, Antigravity, Grok) **+** any OpenAI-compatible HTTP server (vLLM, Ollama, MLX, LM Studio) **+** custom plugins.
 - 🧭 **Smart routing** — alias-based model mapping with priority fallback chains, per-model provider overrides, and session reuse (`codex exec resume`).
 - ⚙️ **Multiple execution modes** — `cli`, Claude **Agent SDK**, Codex **app-server**, and the new **channel-worker** bridge mode.
 - 📡 **Real SSE streaming** — native NDJSON/JSONL event pipes, not fake post-hoc chunking.
@@ -69,7 +69,7 @@ npm run dev:dashboard  # dashboard   → http://localhost:5300
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Claude Pro / Max | `npm i -g @anthropic-ai/claude-code` |
 | [Codex](https://github.com/openai/codex) | ChatGPT Plus / Pro | `npm i -g @openai/codex` |
 | [Copilot CLI](https://docs.github.com/en/copilot) | GitHub Copilot | `gh extension install github/gh-copilot` |
-| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google AI Studio | `npm i -g @google/gemini-cli` |
+| ~~Gemini CLI~~ *(discontinued)* | — | use **Antigravity CLI** below — Gemini CLI was discontinued by Google |
 | [Antigravity CLI](https://antigravity.google/) | Google AI Pro / Ultra | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` |
 | [Grok Build CLI](https://x.ai/cli) | SuperGrok / X Premium+ | `curl -fsSL https://x.ai/cli/install.sh \| bash` |
 | **HTTP** | any OpenAI-compatible server | add from the dashboard (vLLM, Ollama, MLX, LM Studio…) |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -92,16 +92,21 @@ providers:
     # working_dir: "/path/to/project"
     # 인증: COPILOT_GITHUB_TOKEN 환경변수 또는 사전 `copilot` OAuth 로그인 필요
 
+  # Gemini CLI (gemini) — DEPRECATED / 단종.
+  # Google이 Gemini CLI를 단종하고 Antigravity CLI(agy)로 대체했습니다(아래 agy 참고).
+  # gemini provider 코드는 유지되어 있으므로, Gemini CLI가 다시 제공되면
+  # enabled: true + cli_path 지정만으로 복구할 수 있습니다.
+  # 빌트인이라 블록을 통째로 지우면 기본값으로 다시 enabled되므로 enabled: false로 명시합니다.
   gemini:
-    enabled: true
-    cli_path: "gemini"
-    default_model: "gemini-2.5-pro"
-    max_concurrent: 10
-    timeout_ms: 300000
-    extra_args:
-      - "--yolo"                       # tool 자동 승인 (headless 모드 필수)
-      - "--skip-trust"                 # headless 실행 시 trusted folder 프롬프트 방지
-    # working_dir: "/path/to/project"  # 에이전틱 파일 작업 시 필수
+    enabled: false
+    # cli_path: "gemini"
+    # default_model: "gemini-2.5-pro"
+    # max_concurrent: 10
+    # timeout_ms: 300000
+    # extra_args:
+    #   - "--yolo"                       # tool 자동 승인 (headless 모드 필수)
+    #   - "--skip-trust"                 # headless 실행 시 trusted folder 프롬프트 방지
+    # working_dir: "/path/to/project"    # 에이전틱 파일 작업 시 필수
 
   # Google Antigravity CLI (agy) — 2026-05-19 Google I/O 2026 발표, 1.0.0 기준.
   # Gemini CLI의 후계자로 Google이 이전 권장. AI Pro/Ultra 구독 + 사전 Google OAuth 로그인 필요
@@ -109,7 +114,7 @@ providers:
   #
   # 1.0.0 한계 (구현 시 반영됨):
   #   - -m/--model 미지원 → 매핑된 actual_model은 응답 메타데이터 표시용으로만 사용.
-  #     agy 자체 백엔드가 모델 선택. 정확한 모델 강제가 필요하면 gemini provider 사용 권장.
+  #     agy 자체 백엔드가 모델 선택(특정 Gemini 모델 강제 불가).
   #   - --json/--stream-json 미지원 → 출력은 plain text. 토큰 사용량은 추정값(estimateTokens).
   #   - 명시적 스트리밍 없음 → 단일-청크 가짜 스트리밍으로 wrap(클라이언트 호환 유지).
   #   - 세션 연속성은 매 호출 신규(messages 전체를 매번 prompt로 직렬화).
@@ -170,8 +175,6 @@ rate_limits:
     codex:
       rpm: 20
     copilot:
-      rpm: 20
-    gemini:
       rpm: 20
     agy:
       rpm: 20
@@ -240,13 +243,8 @@ model_mappings:
   - alias: "copilot-gpt"
     provider: "copilot"
     actual_model: "gpt-5.4"
-  # Gemini models
-  - alias: "gemini-pro"
-    provider: "gemini"
-    actual_model: "gemini-2.5-pro"
-  - alias: "gemini-flash"
-    provider: "gemini"
-    actual_model: "gemini-2.5-flash"
+  # Gemini CLI는 단종됨(agy로 대체) → gemini-pro/gemini-flash 매핑 제거.
+  # gemini provider를 다시 켜면 여기에 매핑을 추가하세요.
   # Antigravity (agy) — 1.0.0은 모델 플래그 없음. actual_model은 표시용.
   - alias: "antigravity"
     provider: "agy"

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -55,6 +55,8 @@ Claude 프로바이더는 두 가지 실행 모드를 지원합니다:
 
 ### Gemini Provider (`gemini-provider.ts`)
 
+> ⚠️ **단종(DEPRECATED)**: Google이 Gemini CLI(`@google/gemini-cli`)를 단종하고 **Antigravity CLI(`agy`)**로 대체했습니다. 기본 설정(`config.example.yaml`)에서 gemini provider는 `enabled: false`로 비활성화되어 있습니다. provider 코드는 복구 가능성을 위해 유지되며, Gemini CLI가 다시 제공되면 config에서 `enabled: true`로 되살릴 수 있습니다. 아래 내용은 유지된 코드의 동작 설명입니다.
+
 | 항목 | 설명 |
 |------|------|
 | CLI | `gemini` |

--- a/packages/dashboard/src/i18n/translations.ts
+++ b/packages/dashboard/src/i18n/translations.ts
@@ -565,6 +565,10 @@ export const translations: Record<Lang, Record<string, string>> = {
     'guide.tipHealthDesc': 'GET /health is accessible without authentication',
     'guide.tipContentParts': 'Content parts:',
     'guide.tipContentPartsDesc': 'Messages support array content with text and image_url types (base64 or URL)',
+    'guide.vision': 'Vision / Image Input',
+    'guide.visionDescription': 'For the Antigravity (agy) provider, attach a local image by referencing its file path inline with the @ prefix — agy resolves the @ workspace file reference, attaches the image, and sends it to the Gemini vision backend. Use an absolute path (or one relative to the provider working_dir); the file must be readable by the proxy process.',
+    'guide.visionAgyExample': 'Image input with agy (@ file reference)',
+    'guide.visionNote': 'Prefer @<path> over inlining base64. For agy, image_url / base64 content parts are reduced to a plain [image] marker and are NOT sent as image data — and large base64 needlessly bloats the request. (The gemini provider, if re-enabled, auto-converts standard image_url parts to a temp-file @<path>.)',
   },
   ko: {
     // 사이드바
@@ -1129,5 +1133,9 @@ export const translations: Record<Lang, Record<string, string>> = {
     'guide.tipHealthDesc': 'GET /health는 인증 없이 접근 가능',
     'guide.tipContentParts': 'Content parts:',
     'guide.tipContentPartsDesc': '메시지 content에 text와 image_url 타입의 배열을 지원합니다 (base64 또는 URL)',
+    'guide.vision': '비전 / 이미지 입력',
+    'guide.visionDescription': 'Antigravity(agy) provider에서는 이미지 파일 경로를 텍스트에 @ 접두사로 인라인 참조하면 됩니다 — agy가 @ workspace 파일 참조를 해석해 이미지를 첨부하고 Gemini 비전 백엔드로 전송합니다. 절대 경로(또는 provider working_dir 기준 상대 경로)를 쓰고, 해당 파일은 프록시 프로세스가 읽을 수 있어야 합니다.',
+    'guide.visionAgyExample': 'agy로 이미지 입력 (@ 파일 참조)',
+    'guide.visionNote': 'base64를 인라인하는 것보다 @<경로>를 권장합니다. agy에서는 image_url / base64 content part가 단순 [image] 마커로 치환되어 실제 이미지 데이터로 전송되지 않으며, 큰 base64는 요청을 불필요하게 키웁니다. (gemini provider를 다시 켜면 표준 image_url part를 임시파일 @<경로>로 자동 변환합니다.)',
   },
 };

--- a/packages/dashboard/src/pages/ApiGuidePage.tsx
+++ b/packages/dashboard/src/pages/ApiGuidePage.tsx
@@ -201,7 +201,7 @@ print(response.choices[0].message.content)
 
 # Streaming
 stream = client.chat.completions.create(
-    model="gemini-pro",
+    model="antigravity",
     messages=[{"role": "user", "content": "Write a haiku"}],
     stream=True,
 )
@@ -241,6 +241,25 @@ for await (const chunk of stream) {
 {`curl ${apiBase}/v1/models \\
   -H "Authorization: Bearer sk-proxy-your-key-here"`}
         </CodeBlock>
+      </Section>
+
+      {/* 비전 / 이미지 입력 */}
+      <Section title={t('guide.vision')}>
+        <p className="text-sm text-gray-600 dark:text-gray-400">{t('guide.visionDescription')}</p>
+        <CodeBlock title={t('guide.visionAgyExample')} lang="bash">
+{`curl ${apiBase}/v1/chat/completions \\
+  -H "Authorization: Bearer sk-proxy-your-key-here" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "antigravity",
+    "messages": [
+      {"role": "user", "content": "Describe this image: @/absolute/path/to/image.png"}
+    ]
+  }'`}
+        </CodeBlock>
+        <div className="bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg p-3 text-sm text-amber-700 dark:text-amber-300">
+          {t('guide.visionNote')}
+        </div>
       </Section>
 
       {/* 응답 형식 */}


### PR DESCRIPTION
## Summary
Addresses the feedback in #36 from @deadcoder0904.

- **Vision / image input guide** — the `/guide` page now documents how to send images to the `agy` (Antigravity) provider using the `@<path>` inline file reference, since `agy` reduces base64 / `image_url` content parts to a plain `[image]` marker (the original pain point). Includes a curl example, a prefer-`@`-over-base64 note, and EN/KO strings. The streaming example alias was switched from the removed `gemini-pro` to `antigravity`.
- **Deprecate Gemini CLI** — Google discontinued `@google/gemini-cli` (replaced by Antigravity). The `gemini` provider is now `enabled: false` by default and marked deprecated in the README (×2) and provider-architecture docs. Provider **code is kept intact** (`gemini-provider.ts`, `PROVIDER_NAMES`, loader defaults) so re-enabling is a config-only change if the CLI ever returns.
- **Favicon** — already present (`packages/dashboard/public/favicon.svg`, referenced in `index.html`); no change needed.

### Scope note
- The active local `config.yaml` is gitignored, so its gemini disable/mapping removal is applied locally only (not in this PR). A server restart is needed for it to take effect (no config hot-reload).
- `gemini` is a built-in provider, so deleting the block entirely would re-enable it via loader defaults — hence the explicit `enabled: false`.

## Test plan
- [x] `npm run build` — shared → server → dashboard all compile (TSX + i18n changes included)
- [x] `npm test` — 22 files, **207 passed / 1 skipped** (no regressions; flip-centered gating clean)
- [x] `config.yaml` parses; `gemini.enabled = false`, gemini mappings = 0
- [x] No dangling `gemini-pro`/`gemini-flash` references except retained loader fallback defaults (intentional, code kept)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)