### PR TITLE
feat(grok): --effort reasoning wiring + grok-composer-2.5-fast (#40)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -138,10 +138,13 @@ providers:
   # SuperGrok / X Premium+ 구독 + 사전 로그인 필요 (grok login). 설치 후 `grok models`로 모델 확인.
   # 헤드리스 단발 실행: grok -m <model> -p "<prompt>" → stdout plain text.
   #
-  # 동작 (구현 시 반영됨):
-  #   - -m/--model 지원 → 매핑된 actual_model을 실제로 전달. 현재 `grok models`는 grok-build 1종(default) 노출.
+  # 동작 (구현 시 반영됨, grok 0.2.60 기준):
+  #   - -m/--model 지원 → 매핑된 actual_model을 실제로 전달. `grok models`:
+  #     grok-build(default, reasoning) + grok-composer-2.5-fast.
+  #   - --effort 지원 → 매핑의 reasoning_effort(low/medium/high/xhigh/max)를 그대로 --effort로 전달.
+  #     단 effort는 모델별: grok-build만 지원, grok-composer-2.5-fast는 미지원(설정 시 API 400).
   #   - 출력은 plain text(stdout). 토큰 사용량은 추정값(estimateTokens).
-  #   - 단일-청크 가짜 스트리밍으로 wrap(클라이언트 호환 유지). --reasoning-effort는 미배선(매핑에서 무시).
+  #   - 단일-청크 가짜 스트리밍으로 wrap(클라이언트 호환 유지).
   #   - 세션 연속성은 매 호출 신규(messages 전체를 매번 prompt로 직렬화).
   grok:
     enabled: true
@@ -262,7 +265,12 @@ model_mappings:
     provider: "agy"
     actual_model: "Gemini 3.5 Flash (High)"
 
-  # xAI Grok Build — 최신 단일 모델 (grok models의 기본값)
+  # xAI Grok Build — grok-build(reasoning, default) + grok-composer-2.5-fast.
   - alias: "grok-build"
     provider: "grok"
     actual_model: "grok-build"
+    # grok-build는 --effort 지원. 추론 수준이 필요하면 reasoning_effort를 설정:
+    # reasoning_effort: "high"          # low|medium|high|xhigh|max
+  - alias: "grok-composer"
+    provider: "grok"
+    actual_model: "grok-composer-2.5-fast"   # [주의] effort 미지원 → reasoning_effort 설정 금지

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -269,8 +269,11 @@ model_mappings:
   - alias: "grok-build"
     provider: "grok"
     actual_model: "grok-build"
-    # grok-build는 --effort 지원. 추론 수준이 필요하면 reasoning_effort를 설정:
-    # reasoning_effort: "high"          # low|medium|high|xhigh|max
   - alias: "grok-composer"
     provider: "grok"
     actual_model: "grok-composer-2.5-fast"   # [주의] effort 미지원 → reasoning_effort 설정 금지
+  # grok-build는 --effort 지원 → reasoning_effort로 추론 수준 프리셋(low|medium|high|xhigh|max).
+  - alias: "grok-build-high"
+    provider: "grok"
+    actual_model: "grok-build"
+    reasoning_effort: "high"

--- a/packages/dashboard/src/pages/ModelMappingsPage.tsx
+++ b/packages/dashboard/src/pages/ModelMappingsPage.tsx
@@ -671,9 +671,9 @@ export default function ModelMappingsPage() {
                 <select
                   value={form.reasoning_effort}
                   onChange={(e) => setForm({ ...form, reasoning_effort: e.target.value as ReasoningEffortValue })}
-                  disabled={form.provider === 'gemini' || form.provider === 'agy' || form.provider === 'grok'}
+                  disabled={form.provider === 'gemini' || form.provider === 'agy'}
                   className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded px-3 py-2 text-sm text-gray-800 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                  title={(form.provider === 'gemini' || form.provider === 'agy' || form.provider === 'grok') ? t('models.reasoningEffortUnsupported') : t('models.reasoningEffortHelp')}
+                  title={(form.provider === 'gemini' || form.provider === 'agy') ? t('models.reasoningEffortUnsupported') : t('models.reasoningEffortHelp')}
                 >
                   {REASONING_EFFORT_OPTIONS.map((value) => (
                     <option key={value || 'default'} value={value}>

--- a/packages/server/src/providers/grok-provider.test.ts
+++ b/packages/server/src/providers/grok-provider.test.ts
@@ -99,6 +99,47 @@ describe('GrokProvider.buildArgs', () => {
       ),
     ).toThrow(/prompt exceeds/);
   });
+
+  it('reasoningEffort를 --effort로 리맵 없이 그대로 전달', () => {
+    const provider = new GrokProvider(baseConfig());
+    for (const effort of ['low', 'medium', 'high', 'xhigh', 'max'] as const) {
+      const args = (provider as unknown as BuildArgs).buildArgs(
+        baseOptions({ reasoningEffort: effort }),
+      );
+      expect(args[args.indexOf('--effort') + 1]).toBe(effort);
+    }
+  });
+
+  it('reasoningEffort 미지정 시 --effort 플래그 없음', () => {
+    const provider = new GrokProvider(baseConfig());
+    const args = (provider as unknown as BuildArgs).buildArgs(baseOptions());
+    expect(args).not.toContain('--effort');
+  });
+
+  it('extra_args에 --effort가 있으면 reasoningEffort를 중복 추가하지 않음', () => {
+    const provider = new GrokProvider(baseConfig({ extra_args: ['--effort', 'low'] }));
+    const args = (provider as unknown as BuildArgs).buildArgs(
+      baseOptions({ reasoningEffort: 'high' }),
+    );
+    expect(args.filter((a) => a === '--effort')).toHaveLength(1);
+    expect(args).not.toContain('high');
+  });
+
+  it('extra_args에 --reasoning-effort가 있어도 중복 --effort를 추가하지 않음', () => {
+    const provider = new GrokProvider(baseConfig({ extra_args: ['--reasoning-effort', 'low'] }));
+    const args = (provider as unknown as BuildArgs).buildArgs(
+      baseOptions({ reasoningEffort: 'high' }),
+    );
+    expect(args).not.toContain('--effort');
+  });
+
+  it('--effort는 -p prompt 앞에 위치 (print-mode 파싱)', () => {
+    const provider = new GrokProvider(baseConfig());
+    const args = (provider as unknown as BuildArgs).buildArgs(
+      baseOptions({ reasoningEffort: 'high' }),
+    );
+    expect(args.indexOf('--effort')).toBeLessThan(args.indexOf('-p'));
+  });
 });
 
 describe('GrokProvider.execute (plain text 파싱)', () => {

--- a/packages/server/src/providers/grok-provider.ts
+++ b/packages/server/src/providers/grok-provider.ts
@@ -26,7 +26,11 @@ function estimateTokens(text: string): TokenUsage {
  * 동작:
  *  - 헤드리스 단발 실행: `grok -m <model> -p <prompt>` → stdout에 응답 plain text 출력 후 종료.
  *  - -m/--model 지원 → 매핑된 actual_model을 실제로 전달 (agy와의 핵심 차이).
- *    `grok models`가 노출하는 모델은 현재 `grok-build` 1종(default).
+ *    `grok models`(0.2.60): `grok-build`(default, reasoning) + `grok-composer-2.5-fast`.
+ *  - --effort 지원(0.2.x) → low/medium/high/xhigh/max가 cliproxy ReasoningEffort와 정확히
+ *    일치해 **리맵 없이 그대로 전달**(copilot/codex와의 차이). 매핑별 reasoning_effort opt-in.
+ *    [gotcha] effort는 모델별 — `grok-composer-2.5-fast`는 effort 미지원(API 400)이라
+ *    composer 매핑에는 reasoning_effort를 설정하지 말 것. reasoning 모델(grok-build)만 지원.
  *  - --output-format은 streaming-json도 지원하나, 안정성·단순성을 위해 plain 단발 후
  *    executeStream에서 단일 text_delta + done으로 가짜 스트리밍 wrap (agy와 동일 전략).
  *  - 세션 연속성은 매 호출 신규 (-c/--continue, -r/--resume은 사용자가 extra_args로만 옵트인).
@@ -53,10 +57,20 @@ export class GrokProvider extends BaseProvider {
       );
     }
 
+    // 추론 수준 주입 (--effort). grok은 low/medium/high/xhigh/max를 모두 지원하므로
+    // ReasoningEffort 값을 리맵 없이 그대로 전달한다. 사용자가 extra_args에 --effort 또는
+    // --reasoning-effort를 이미 넣었으면 건너뛴다.
+    const userHasEffort = this.config.extra_args.some(
+      (arg) => arg === '--effort' || arg === '--reasoning-effort',
+    );
+    const effortArgs = options.reasoningEffort && !userHasEffort
+      ? ['--effort', options.reasoningEffort]
+      : [];
+
     // 사용자 extra_args를 모델/프롬프트 플래그 앞에 배치해 print-mode 옵션이 이 실행에 적용되게 함.
     // -p <prompt>는 마지막에 두어 프롬프트가 마지막 인수가 되도록 보장.
     const modelArgs = model ? ['-m', model] : [];
-    return [...this.config.extra_args, ...modelArgs, '-p', prompt];
+    return [...this.config.extra_args, ...effortArgs, ...modelArgs, '-p', prompt];
   }
 
   // grok은 plain text를 stdout으로 흘리므로 BaseProvider의 NDJSON 라인 파싱을 우회.


### PR DESCRIPTION
## Summary

agy #38 점검의 후속으로 grok CLI(0.2.13 → **0.2.60**) 변경사항 반영.

- **`--effort` reasoning 배선**: grok 0.2.60의 `--effort low|medium|high|xhigh|max`가 cliproxy `ReasoningEffort` enum과 **정확히 일치** → `options.reasoningEffort`를 **리맵 없이 그대로** `--effort`로 전달(copilot의 max→xhigh, codex의 xhigh/max→high 같은 리맵 불필요). extra_args에 `--effort`/`--reasoning-effort`가 있으면 skip.
- **신규 모델**: `grok models`에 추가된 `grok-composer-2.5-fast` 매핑 등록.
- **대시보드**: grok을 reasoning-effort 비활성 목록에서 제거(미배선이라 막아뒀던 것 → 이제 입력 가능).

## ⚠️ gotcha (실측)
`--effort`는 **모델별**입니다:
- `grok -m grok-build --effort high -p` → `OK` (reasoning 모델 지원) ✓
- `grok-composer-2.5-fast` + effort → API 400 `does not support parameter reasoningEffort`

effort는 매핑별 `reasoning_effort` opt-in이므로 grok-build 매핑에만 설정하면 안전합니다. composer 매핑에는 설정하지 않도록 config 주석에 명시.

## Test plan
- [x] `npm run build` 성공
- [x] `npm test` — 215 passed / 1 skipped, 회귀 0건 (기준선 210 → 215, grok 신규 5건)
- [x] grok 단위 테스트 16건 통과 (effort 5단계 passthrough / 미지정 시 무 / extra_args --effort·--reasoning-effort 중복 방지 / -p 앞 위치)
- [x] config Zod 검증: `loadConfig(config.yaml/config.example.yaml)` 통과, grok 매핑 파싱
- [x] **실 grok 0.2.60 스모크** (provider 인수 순서 그대로): `grok --effort high -m grok-build -p` → `OK` exit 0

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)