### PR TITLE
feat(agy): add Gemini 3.1 Pro (Low/High) model mappings (#42)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -264,6 +264,13 @@ model_mappings:
   - alias: "gemini-3.5-flash-high"
     provider: "agy"
     actual_model: "Gemini 3.5 Flash (High)"
+  # Gemini 3.1 Pro reasoning 프리셋 (Low/High만 — Medium 없음).
+  - alias: "gemini-3.1-pro-low"
+    provider: "agy"
+    actual_model: "Gemini 3.1 Pro (Low)"
+  - alias: "gemini-3.1-pro-high"
+    provider: "agy"
+    actual_model: "Gemini 3.1 Pro (High)"
 
   # xAI Grok Build — grok-build(reasoning, default) + grok-composer-2.5-fast.
   - alias: "grok-build"


### PR DESCRIPTION
## Summary

이슈 #38 댓글(@deadcoder0904: "Can u do it for gemini-3.1-pro (high) & (low) both??? That's missing") 반영. PR #39는 agy의 Gemini 3.5 Flash 3종만 매핑했고, `agy models`의 **Gemini 3.1 Pro (Low)/(High)** 2종이 누락됐던 것.

- `gemini-3.1-pro-low` → `"Gemini 3.1 Pro (Low)"`
- `gemini-3.1-pro-high` → `"Gemini 3.1 Pro (High)"`

3.1 Pro는 Medium 변형이 없어 Low/High 둘뿐(#39의 Flash와 동일 패턴, 표시명 라벨 사용).

## Test plan
- [x] 실 agy 라벨 해석 확인: resolver 로그 `Propagating ... label="Gemini 3.1 Pro (High/Low)"` (조용한 폴백 아님)
- [x] config Zod 검증: `loadConfig(config.yaml/config.example.yaml)` 통과
- [x] 라이브 DB 등록 + `/admin/test-model`: 두 모델 `success=true`, 응답 "OK"
- [x] 라우팅 E2E: `gemini-3.1-pro-high` alias → debug cliArgs `["...agy","--model","Gemini 3.1 Pro (High)","-p","Say OK"]`

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)